### PR TITLE
Extract SQMeter poller into internal package

### DIFF
--- a/cmd/sqmeter-alpaca-safetymonitor/main.go
+++ b/cmd/sqmeter-alpaca-safetymonitor/main.go
@@ -11,15 +11,13 @@ import (
 	"os/signal"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"syscall"
 	"time"
 
 	"sqmeter-alpaca-safetymonitor/internal/alpaca"
 	"sqmeter-alpaca-safetymonitor/internal/config"
 	"sqmeter-alpaca-safetymonitor/internal/discovery"
-	"sqmeter-alpaca-safetymonitor/internal/safety"
-	"sqmeter-alpaca-safetymonitor/internal/sqmclient"
+	"sqmeter-alpaca-safetymonitor/internal/poller"
 	"sqmeter-alpaca-safetymonitor/internal/state"
 	"sqmeter-alpaca-safetymonitor/internal/web"
 )
@@ -95,7 +93,7 @@ func main() {
 
 	stateHolder := state.NewHolder(cfg.ConnectedOnStartup)
 
-	pol := newPoller(cfgHolder, stateHolder, logger)
+	pol := poller.New(cfgHolder, stateHolder, logger)
 
 	webHandler, err := web.New(cfgHolder, stateHolder)
 	if err != nil {
@@ -103,9 +101,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	alpacaHandler := alpaca.New(cfgHolder, stateHolder, deviceUUID, version, func(ctx context.Context) {
-		pol.PollNow(ctx)
-	})
+	alpacaHandler := alpaca.New(cfgHolder, stateHolder, deviceUUID, version, pol.PollNow)
 
 	mux := http.NewServeMux()
 	alpacaHandler.Register(mux)
@@ -168,113 +164,6 @@ func main() {
 
 	wg.Wait()
 	logger.Info("stopped")
-}
-
-// ---------- poller -----------------------------------------------------------
-
-type poller struct {
-	cfgHolder   *config.Holder
-	stateHolder *state.Holder
-	logger      *slog.Logger
-
-	mu                    sync.Mutex
-	client                *sqmclient.Client
-	currentURL            string
-	hasData               bool
-	lastSensors           *sqmclient.SensorsResponse
-	lastSuccessfulPollUTC time.Time
-	lastPollUTC           time.Time
-	lastError             string
-
-	lastPollNano atomic.Int64 // unix nano of last poll start, for interval check
-}
-
-func newPoller(cfgHolder *config.Holder, stateHolder *state.Holder, logger *slog.Logger) *poller {
-	cfg := cfgHolder.Get()
-	return &poller{
-		cfgHolder:   cfgHolder,
-		stateHolder: stateHolder,
-		logger:      logger,
-		client:      sqmclient.New(cfg.SQMeterBaseURL),
-		currentURL:  cfg.SQMeterBaseURL,
-	}
-}
-
-// Run performs an initial poll then re-polls on the configured interval.
-// The interval is read from the config holder on every tick, so it can be
-// changed at runtime without restarting.
-func (p *poller) Run(ctx context.Context) {
-	p.PollNow(ctx)
-
-	ticker := time.NewTicker(time.Second) // 1-second base tick
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			cfg := p.cfgHolder.Get()
-			interval := time.Duration(cfg.PollIntervalSeconds) * time.Second
-			lastNano := p.lastPollNano.Load()
-			if lastNano == 0 || time.Since(time.Unix(0, lastNano)) >= interval {
-				p.PollNow(ctx)
-			}
-		case <-ctx.Done():
-			return
-		}
-	}
-}
-
-// PollNow executes one poll cycle immediately (safe for concurrent callers).
-func (p *poller) PollNow(ctx context.Context) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.doPoll(ctx)
-}
-
-func (p *poller) doPoll(ctx context.Context) {
-	cfg := p.cfgHolder.Get()
-
-	// Rebuild client if SQMeter URL changed (hot-reload).
-	if cfg.SQMeterBaseURL != p.currentURL {
-		p.client = sqmclient.New(cfg.SQMeterBaseURL)
-		p.currentURL = cfg.SQMeterBaseURL
-		p.logger.Info("SQMeter URL updated", "url", cfg.SQMeterBaseURL)
-	}
-
-	now := time.Now().UTC()
-	p.lastPollUTC = now
-	p.lastPollNano.Store(now.UnixNano())
-
-	sensors, err := p.client.FetchSensors(ctx)
-	if err != nil {
-		p.lastError = err.Error()
-		p.logger.Warn("SQMeter poll failed", "error", err)
-	} else {
-		p.lastError = ""
-		p.hasData = true
-		p.lastSensors = sensors
-		p.lastSuccessfulPollUTC = now
-		p.logger.Debug("SQMeter poll ok",
-			"sqm", sensors.SkyQuality.SQM,
-			"cloud_pct", sensors.CloudConditions.CloudCoverPercent,
-		)
-	}
-
-	if cfg.ManualOverride == "force_safe" {
-		p.logger.Warn("force_safe override active — reporting safe regardless of conditions")
-	}
-
-	evaluated := safety.Evaluate(cfg, safety.Input{
-		Connected:             p.stateHolder.IsConnected(),
-		HasData:               p.hasData,
-		Sensors:               p.lastSensors,
-		LastSuccessfulPollUTC: p.lastSuccessfulPollUTC,
-		LastPollUTC:           now,
-		LastError:             p.lastError,
-	})
-
-	p.stateHolder.Update(evaluated)
-	p.logger.Debug("safety evaluated", "isSafe", evaluated.IsSafe, "reasons", len(evaluated.Reasons))
 }
 
 // ---------- helpers ----------------------------------------------------------

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -1,0 +1,122 @@
+package poller
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"sqmeter-alpaca-safetymonitor/internal/config"
+	"sqmeter-alpaca-safetymonitor/internal/safety"
+	"sqmeter-alpaca-safetymonitor/internal/sqmclient"
+	"sqmeter-alpaca-safetymonitor/internal/state"
+)
+
+// Poller periodically fetches SQMeter sensor data, evaluates safety rules,
+// and writes the result into the state holder.
+type Poller struct {
+	cfgHolder   *config.Holder
+	stateHolder *state.Holder
+	logger      *slog.Logger
+
+	mu                    sync.Mutex
+	client                *sqmclient.Client
+	currentURL            string
+	hasData               bool
+	lastSensors           *sqmclient.SensorsResponse
+	lastSuccessfulPollUTC time.Time
+	lastPollUTC           time.Time
+	lastError             string
+
+	lastPollNano atomic.Int64
+}
+
+// New creates a Poller wired to the given holders.
+func New(cfgHolder *config.Holder, stateHolder *state.Holder, logger *slog.Logger) *Poller {
+	cfg := cfgHolder.Get()
+	return &Poller{
+		cfgHolder:   cfgHolder,
+		stateHolder: stateHolder,
+		logger:      logger,
+		client:      sqmclient.New(cfg.SQMeterBaseURL),
+		currentURL:  cfg.SQMeterBaseURL,
+	}
+}
+
+// Run performs an initial poll then re-polls on the configured interval.
+// It blocks until ctx is cancelled.  The interval is read from the config
+// holder on every tick so it can be changed at runtime without restarting.
+func (p *Poller) Run(ctx context.Context) {
+	p.PollNow(ctx)
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			cfg := p.cfgHolder.Get()
+			interval := time.Duration(cfg.PollIntervalSeconds) * time.Second
+			lastNano := p.lastPollNano.Load()
+			if lastNano == 0 || time.Since(time.Unix(0, lastNano)) >= interval {
+				p.PollNow(ctx)
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// PollNow executes one poll cycle immediately (safe for concurrent callers).
+func (p *Poller) PollNow(ctx context.Context) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.doPoll(ctx)
+}
+
+func (p *Poller) doPoll(ctx context.Context) {
+	cfg := p.cfgHolder.Get()
+
+	// Rebuild client if SQMeter URL changed (hot-reload).
+	if cfg.SQMeterBaseURL != p.currentURL {
+		p.client = sqmclient.New(cfg.SQMeterBaseURL)
+		p.currentURL = cfg.SQMeterBaseURL
+		p.logger.Info("SQMeter URL updated", "url", cfg.SQMeterBaseURL)
+	}
+
+	now := time.Now().UTC()
+	p.lastPollUTC = now
+	p.lastPollNano.Store(now.UnixNano())
+
+	sensors, err := p.client.FetchSensors(ctx)
+	if err != nil {
+		p.lastError = err.Error()
+		p.logger.Warn("SQMeter poll failed", "error", err)
+	} else {
+		p.lastError = ""
+		p.hasData = true
+		p.lastSensors = sensors
+		p.lastSuccessfulPollUTC = now
+		p.logger.Debug("SQMeter poll ok",
+			"sqm", sensors.SkyQuality.SQM,
+			"cloud_pct", sensors.CloudConditions.CloudCoverPercent,
+		)
+	}
+
+	if cfg.ManualOverride == "force_safe" {
+		p.logger.Warn("force_safe override active — reporting safe regardless of conditions")
+	}
+
+	evaluated := safety.Evaluate(cfg, safety.Input{
+		Connected:             p.stateHolder.IsConnected(),
+		HasData:               p.hasData,
+		Sensors:               p.lastSensors,
+		LastSuccessfulPollUTC: p.lastSuccessfulPollUTC,
+		LastPollUTC:           now,
+		LastError:             p.lastError,
+	})
+
+	p.stateHolder.Update(evaluated)
+	p.logger.Debug("safety evaluated", "isSafe", evaluated.IsSafe, "reasons", len(evaluated.Reasons))
+}

--- a/internal/poller/poller_test.go
+++ b/internal/poller/poller_test.go
@@ -1,0 +1,324 @@
+package poller_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"sqmeter-alpaca-safetymonitor/internal/config"
+	"sqmeter-alpaca-safetymonitor/internal/poller"
+	"sqmeter-alpaca-safetymonitor/internal/sqmclient"
+	"sqmeter-alpaca-safetymonitor/internal/state"
+)
+
+func silentLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func clearSensors() sqmclient.SensorsResponse {
+	return sqmclient.SensorsResponse{
+		SkyQuality:  sqmclient.SkyQuality{SQM: 21.5, Bortle: 2.0},
+		Environment: sqmclient.Environment{Temperature: 12.4, Humidity: 60.0, Dewpoint: 5.0},
+		IRTemperature: sqmclient.IRTemperature{
+			ObjectTemp: -15.0, AmbientTemp: 12.4, Status: 0,
+		},
+		LightSensor: sqmclient.LightSensor{Status: 0},
+		CloudConditions: sqmclient.CloudConditions{
+			CloudCoverPercent: 5.0, Description: "Clear",
+		},
+	}
+}
+
+func newFakeSQM(sensors sqmclient.SensorsResponse) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/sensors":
+			json.NewEncoder(w).Encode(sensors)
+		case "/api/status":
+			json.NewEncoder(w).Encode(map[string]any{"uptime": 3600})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func newFakeSQMError() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "device error", http.StatusInternalServerError)
+	}))
+}
+
+func defaultCfg(sqmURL string) *config.Config {
+	cfg := config.Defaults()
+	cfg.SQMeterBaseURL = sqmURL
+	cfg.FailClosed = true
+	cfg.ConnectedOnStartup = true
+	return cfg
+}
+
+// ---------- PollNow: success path --------------------------------------------
+
+func TestPollNow_UpdatesStateWithSensorData(t *testing.T) {
+	srv := newFakeSQM(clearSensors())
+	defer srv.Close()
+
+	cfg := defaultCfg(srv.URL)
+	cfgHolder := config.NewHolder(cfg, "")
+	stateHolder := state.NewHolder(true)
+
+	p := poller.New(cfgHolder, stateHolder, silentLogger())
+	p.PollNow(context.Background())
+
+	ev := stateHolder.Get()
+	if !ev.IsSafe {
+		t.Errorf("expected IsSafe=true after successful poll with clear sky, reasons: %v", ev.Reasons)
+	}
+	if ev.Values.SQM != 21.5 {
+		t.Errorf("Values.SQM: want 21.5, got %v", ev.Values.SQM)
+	}
+	if ev.LastSuccessfulPollUTC.IsZero() {
+		t.Error("LastSuccessfulPollUTC should be set after a successful poll")
+	}
+}
+
+func TestPollNow_IsSafeTrue_WhenConditionsClear(t *testing.T) {
+	sensors := clearSensors()
+	sensors.CloudConditions.CloudCoverPercent = 3.0
+	srv := newFakeSQM(sensors)
+	defer srv.Close()
+
+	cfgHolder := config.NewHolder(defaultCfg(srv.URL), "")
+	stateHolder := state.NewHolder(true)
+
+	p := poller.New(cfgHolder, stateHolder, silentLogger())
+	p.PollNow(context.Background())
+
+	if !stateHolder.Get().IsSafe {
+		t.Errorf("expected safe with clear sky: %v", stateHolder.Get().Reasons)
+	}
+}
+
+// ---------- PollNow: safety rule enforcement ----------------------------------
+
+func TestPollNow_IsSafeFalse_WhenCloudCoverHigh(t *testing.T) {
+	sensors := clearSensors()
+	sensors.CloudConditions.CloudCoverPercent = 90.0
+	srv := newFakeSQM(sensors)
+	defer srv.Close()
+
+	cfgHolder := config.NewHolder(defaultCfg(srv.URL), "")
+	stateHolder := state.NewHolder(true)
+
+	p := poller.New(cfgHolder, stateHolder, silentLogger())
+	p.PollNow(context.Background())
+
+	if stateHolder.Get().IsSafe {
+		t.Error("expected unsafe: cloud cover 90% >= 80% threshold")
+	}
+}
+
+func TestPollNow_IsSafeFalse_WhenDisconnected(t *testing.T) {
+	srv := newFakeSQM(clearSensors())
+	defer srv.Close()
+
+	cfgHolder := config.NewHolder(defaultCfg(srv.URL), "")
+	stateHolder := state.NewHolder(false) // disconnected
+
+	p := poller.New(cfgHolder, stateHolder, silentLogger())
+	p.PollNow(context.Background())
+
+	if stateHolder.Get().IsSafe {
+		t.Error("expected unsafe: device is disconnected")
+	}
+}
+
+// ---------- PollNow: error handling ------------------------------------------
+
+func TestPollNow_SetsLastError_WhenSQMUnreachable(t *testing.T) {
+	cfgHolder := config.NewHolder(defaultCfg("http://127.0.0.1:1"), "")
+	stateHolder := state.NewHolder(true)
+
+	p := poller.New(cfgHolder, stateHolder, silentLogger())
+	p.PollNow(context.Background())
+
+	ev := stateHolder.Get()
+	if ev.LastError == "" {
+		t.Error("expected LastError to be set when SQMeter is unreachable")
+	}
+}
+
+func TestPollNow_IsSafeFalse_WhenNoDataAndFailClosed(t *testing.T) {
+	cfgHolder := config.NewHolder(defaultCfg("http://127.0.0.1:1"), "")
+	stateHolder := state.NewHolder(true)
+
+	p := poller.New(cfgHolder, stateHolder, silentLogger())
+	p.PollNow(context.Background())
+
+	if stateHolder.Get().IsSafe {
+		t.Error("expected unsafe: no data yet and FAIL_CLOSED=true")
+	}
+}
+
+func TestPollNow_IsSafeTrue_WhenNoDataAndFailOpen(t *testing.T) {
+	cfg := defaultCfg("http://127.0.0.1:1")
+	cfg.FailClosed = false
+	cfgHolder := config.NewHolder(cfg, "")
+	stateHolder := state.NewHolder(true)
+
+	p := poller.New(cfgHolder, stateHolder, silentLogger())
+	p.PollNow(context.Background())
+
+	if !stateHolder.Get().IsSafe {
+		t.Errorf("expected safe: no data with FAIL_CLOSED=false, reasons: %v", stateHolder.Get().Reasons)
+	}
+}
+
+func TestPollNow_ServerError_SetsLastError(t *testing.T) {
+	srv := newFakeSQMError()
+	defer srv.Close()
+
+	cfgHolder := config.NewHolder(defaultCfg(srv.URL), "")
+	stateHolder := state.NewHolder(true)
+
+	p := poller.New(cfgHolder, stateHolder, silentLogger())
+	p.PollNow(context.Background())
+
+	if stateHolder.Get().LastError == "" {
+		t.Error("expected LastError when server returns 500")
+	}
+}
+
+// ---------- hot-reload: SQMeter URL change -----------------------------------
+
+func TestPollNow_HotReload_SwitchesURL(t *testing.T) {
+	// Server A returns cloudy (unsafe), server B returns clear (safe).
+	cloudy := clearSensors()
+	cloudy.CloudConditions.CloudCoverPercent = 95.0
+	srvA := newFakeSQM(cloudy)
+	defer srvA.Close()
+
+	srvB := newFakeSQM(clearSensors())
+	defer srvB.Close()
+
+	cfgHolder := config.NewHolder(defaultCfg(srvA.URL), "")
+	stateHolder := state.NewHolder(true)
+
+	p := poller.New(cfgHolder, stateHolder, silentLogger())
+
+	// First poll — points at A, should be unsafe.
+	p.PollNow(context.Background())
+	if stateHolder.Get().IsSafe {
+		t.Error("expected unsafe from server A (cloudy)")
+	}
+
+	// Update URL to B and poll again — should now be safe.
+	updated := *cfgHolder.Get()
+	updated.SQMeterBaseURL = srvB.URL
+	cfgHolder.Update(&updated) //nolint:errcheck
+
+	p.PollNow(context.Background())
+	if !stateHolder.Get().IsSafe {
+		t.Errorf("expected safe after switching to server B: %v", stateHolder.Get().Reasons)
+	}
+}
+
+// ---------- Run: context cancellation ----------------------------------------
+
+func TestRun_StopsOnContextCancel(t *testing.T) {
+	srv := newFakeSQM(clearSensors())
+	defer srv.Close()
+
+	cfg := defaultCfg(srv.URL)
+	cfg.PollIntervalSeconds = 1
+	cfg.StaleAfterSeconds = 10
+	cfgHolder := config.NewHolder(cfg, "")
+	stateHolder := state.NewHolder(true)
+
+	p := poller.New(cfgHolder, stateHolder, silentLogger())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		p.Run(ctx)
+		close(done)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run() did not stop within 3s after context cancellation")
+	}
+}
+
+func TestRun_PollsImmediatelyOnStart(t *testing.T) {
+	srv := newFakeSQM(clearSensors())
+	defer srv.Close()
+
+	cfgHolder := config.NewHolder(defaultCfg(srv.URL), "")
+	stateHolder := state.NewHolder(true)
+
+	p := poller.New(cfgHolder, stateHolder, silentLogger())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		p.Run(ctx)
+		close(done)
+	}()
+
+	// State should be populated very quickly after Run starts (initial poll).
+	deadline := time.After(2 * time.Second)
+	for {
+		if !stateHolder.Get().LastPollUTC.IsZero() {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("poller did not perform initial poll within 2s")
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+	cancel()
+}
+
+// ---------- configuration-driven safety --------------------------------------
+
+func TestPollNow_ConfigChange_BecomesUnsafe(t *testing.T) {
+	// Sensor data: SQM=18, which is below a strict threshold.
+	sensors := clearSensors()
+	sensors.SkyQuality.SQM = 18.0
+	srv := newFakeSQM(sensors)
+	defer srv.Close()
+
+	// Config A: no SQM minimum — safe.
+	cfgA := defaultCfg(srv.URL)
+	cfgHolder := config.NewHolder(cfgA, "")
+	stateHolder := state.NewHolder(true)
+
+	p := poller.New(cfgHolder, stateHolder, silentLogger())
+	p.PollNow(context.Background())
+
+	if !stateHolder.Get().IsSafe {
+		t.Errorf("expected safe with no SQM minimum configured: %v", stateHolder.Get().Reasons)
+	}
+
+	// Config B: SQM minimum 20 — 18.0 is now unsafe.
+	minSQM := 20.0
+	updated := *cfgHolder.Get()
+	updated.SQMMinSafe = &minSQM
+	cfgHolder.Update(&updated) //nolint:errcheck
+
+	p.PollNow(context.Background())
+	if stateHolder.Get().IsSafe {
+		t.Error("expected unsafe after config change raises SQM minimum above current value")
+	}
+}

--- a/internal/safety/evaluator_extra_test.go
+++ b/internal/safety/evaluator_extra_test.go
@@ -1,0 +1,304 @@
+package safety_test
+
+import (
+	"testing"
+	"time"
+
+	"sqmeter-alpaca-safetymonitor/internal/safety"
+)
+
+// ---------- fail-open (no data) ----------------------------------------------
+
+func TestIsSafe_NoDataFailOpen(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.FailClosed = false
+	in := safeInput()
+	in.HasData = false
+	in.Sensors = nil
+	s := safety.Evaluate(cfg, in)
+	if !s.IsSafe {
+		t.Errorf("expected safe: no data with FAIL_CLOSED=false, got reasons: %v", s.Reasons)
+	}
+}
+
+func TestIsSafe_ForceSafeNoDataFailOpen(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.ManualOverride = "force_safe"
+	cfg.FailClosed = false
+	in := safeInput()
+	in.HasData = false
+	in.Sensors = nil
+	s := safety.Evaluate(cfg, in)
+	if !s.IsSafe {
+		t.Errorf("expected safe: force_safe, no data, FAIL_CLOSED=false, got: %v", s.Reasons)
+	}
+	if len(s.Warnings) == 0 {
+		t.Error("expected force_safe warning")
+	}
+}
+
+// ---------- cloud cover boundary ---------------------------------------------
+
+func TestIsSafe_CloudCoverAtExactUnsafeThreshold(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.CloudCoverUnsafePct = 80
+	in := safeInput()
+	in.Sensors.CloudConditions.CloudCoverPercent = 80.0 // exactly at threshold (>=)
+	s := safety.Evaluate(cfg, in)
+	if s.IsSafe {
+		t.Error("expected unsafe: cloud cover at exactly the unsafe threshold (>=)")
+	}
+}
+
+func TestIsSafe_CloudCoverJustBelowUnsafeThreshold(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.CloudCoverUnsafePct = 80
+	in := safeInput()
+	in.Sensors.CloudConditions.CloudCoverPercent = 79.9
+	s := safety.Evaluate(cfg, in)
+	if !s.IsSafe {
+		t.Errorf("expected safe: cloud cover just below unsafe threshold, got: %v", s.Reasons)
+	}
+}
+
+func TestIsSafe_CloudCoverAtExactCautionThreshold(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.CloudCoverCautionPct = 50
+	cfg.CloudCoverUnsafePct = 80
+	in := safeInput()
+	in.Sensors.CloudConditions.CloudCoverPercent = 50.0 // at caution (>=)
+	s := safety.Evaluate(cfg, in)
+	if !s.IsSafe {
+		t.Errorf("expected safe at caution threshold, got: %v", s.Reasons)
+	}
+	if len(s.Warnings) == 0 {
+		t.Error("expected caution warning at exact caution threshold")
+	}
+}
+
+// ---------- SQM boundary -----------------------------------------------------
+
+func TestIsSafe_SQMAtExactMinimum(t *testing.T) {
+	cfg := defaultCfg()
+	minSQM := 19.0
+	cfg.SQMMinSafe = &minSQM
+	in := safeInput()
+	in.Sensors.SkyQuality.SQM = 19.0 // exactly at min — rule is <, so this is safe
+	s := safety.Evaluate(cfg, in)
+	if !s.IsSafe {
+		t.Errorf("expected safe: SQM exactly at minimum (< check), got: %v", s.Reasons)
+	}
+}
+
+func TestIsSafe_SQMJustBelowMinimum(t *testing.T) {
+	cfg := defaultCfg()
+	minSQM := 19.0
+	cfg.SQMMinSafe = &minSQM
+	in := safeInput()
+	in.Sensors.SkyQuality.SQM = 18.99
+	s := safety.Evaluate(cfg, in)
+	if s.IsSafe {
+		t.Error("expected unsafe: SQM just below minimum")
+	}
+}
+
+// ---------- humidity boundary ------------------------------------------------
+
+func TestIsSafe_HumidityAtExactMaximum(t *testing.T) {
+	cfg := defaultCfg()
+	maxHum := 85.0
+	cfg.HumidityMaxSafe = &maxHum
+	in := safeInput()
+	in.Sensors.Environment.Humidity = 85.0 // exactly at max — rule is >, so this is safe
+	s := safety.Evaluate(cfg, in)
+	if !s.IsSafe {
+		t.Errorf("expected safe: humidity exactly at maximum (> check), got: %v", s.Reasons)
+	}
+}
+
+func TestIsSafe_HumidityJustAboveMaximum(t *testing.T) {
+	cfg := defaultCfg()
+	maxHum := 85.0
+	cfg.HumidityMaxSafe = &maxHum
+	in := safeInput()
+	in.Sensors.Environment.Humidity = 85.01
+	s := safety.Evaluate(cfg, in)
+	if s.IsSafe {
+		t.Error("expected unsafe: humidity just above maximum")
+	}
+}
+
+// ---------- dew point margin boundary ----------------------------------------
+
+func TestIsSafe_DewpointMarginAtExactMinimum(t *testing.T) {
+	cfg := defaultCfg()
+	minMargin := 3.0
+	cfg.DewpointMarginMinC = &minMargin
+	in := safeInput()
+	in.Sensors.Environment.Temperature = 13.0
+	in.Sensors.Environment.Dewpoint = 10.0 // margin = 3.0°C exactly — rule is <, so this is safe
+	s := safety.Evaluate(cfg, in)
+	if !s.IsSafe {
+		t.Errorf("expected safe: dew margin exactly at minimum (< check), got: %v", s.Reasons)
+	}
+}
+
+// ---------- sensor disabled --------------------------------------------------
+
+func TestIsSafe_LightSensorError_WhenDisabled(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.RequireLightStatus = false
+	in := safeInput()
+	in.Sensors.LightSensor.Status = 2
+	s := safety.Evaluate(cfg, in)
+	if !s.IsSafe {
+		t.Errorf("expected safe: light sensor error ignored when RequireLightStatus=false, got: %v", s.Reasons)
+	}
+}
+
+func TestIsSafe_EnvSensorError_WhenDisabled(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.RequireEnvStatus = false
+	in := safeInput()
+	in.Sensors.Environment.Status = 1
+	s := safety.Evaluate(cfg, in)
+	if !s.IsSafe {
+		t.Errorf("expected safe: env sensor error ignored when RequireEnvStatus=false, got: %v", s.Reasons)
+	}
+}
+
+func TestIsSafe_IRSensorError_WhenDisabled(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.RequireIRStatus = false
+	in := safeInput()
+	in.Sensors.IRTemperature.Status = 3
+	s := safety.Evaluate(cfg, in)
+	if !s.IsSafe {
+		t.Errorf("expected safe: IR sensor error ignored when RequireIRStatus=false, got: %v", s.Reasons)
+	}
+}
+
+// ---------- multiple simultaneous failures -----------------------------------
+
+func TestIsSafe_MultipleFailures_MultipleReasons(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.CloudCoverUnsafePct = 80
+	cfg.RequireLightStatus = true
+	minSQM := 20.0
+	cfg.SQMMinSafe = &minSQM
+
+	in := safeInput()
+	in.Sensors.CloudConditions.CloudCoverPercent = 90.0 // fail
+	in.Sensors.LightSensor.Status = 1                   // fail
+	in.Sensors.SkyQuality.SQM = 15.0                    // fail
+
+	s := safety.Evaluate(cfg, in)
+	if s.IsSafe {
+		t.Error("expected unsafe with multiple failures")
+	}
+	if len(s.Reasons) < 3 {
+		t.Errorf("expected at least 3 reasons, got %d: %v", len(s.Reasons), s.Reasons)
+	}
+}
+
+// ---------- config change affects outcome ------------------------------------
+
+func TestIsSafe_ConfigChange_BecomesUnsafe(t *testing.T) {
+	in := safeInput()
+	in.Sensors.CloudConditions.CloudCoverPercent = 60.0
+
+	cfgA := defaultCfg()
+	cfgA.CloudCoverUnsafePct = 80 // 60% is safe under this config
+	sA := safety.Evaluate(cfgA, in)
+	if !sA.IsSafe {
+		t.Errorf("expected safe with threshold 80%%, got: %v", sA.Reasons)
+	}
+
+	cfgB := defaultCfg()
+	cfgB.CloudCoverUnsafePct = 50 // 60% is unsafe under this config
+	sB := safety.Evaluate(cfgB, in)
+	if sB.IsSafe {
+		t.Error("expected unsafe after config threshold lowered to 50%")
+	}
+}
+
+// ---------- error propagation ------------------------------------------------
+
+func TestIsSafe_LastErrorPreserved(t *testing.T) {
+	in := safeInput()
+	in.LastError = "connection timeout"
+	s := safety.Evaluate(defaultCfg(), in)
+	if s.LastError != "connection timeout" {
+		t.Errorf("LastError not preserved: got %q", s.LastError)
+	}
+}
+
+func TestIsSafe_PollTimesPreserved(t *testing.T) {
+	now := time.Now().UTC()
+	in := safeInput()
+	in.LastPollUTC = now
+	in.LastSuccessfulPollUTC = now.Add(-5 * time.Second)
+	s := safety.Evaluate(defaultCfg(), in)
+	if !s.LastPollUTC.Equal(now) {
+		t.Error("LastPollUTC not preserved")
+	}
+}
+
+// ---------- stale data with non-zero last success ----------------------------
+
+func TestIsSafe_StaleData_JustBelowThreshold(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.StaleAfterSeconds = 30
+	in := safeInput()
+	// 29 seconds ago — just within the threshold
+	in.LastSuccessfulPollUTC = time.Now().Add(-29 * time.Second)
+	s := safety.Evaluate(cfg, in)
+	if !s.IsSafe {
+		t.Errorf("expected safe: data not yet stale, got: %v", s.Reasons)
+	}
+}
+
+// ---------- SQM not configured (nil pointer) ---------------------------------
+
+func TestIsSafe_SQMNotConfigured_AnyValueSafe(t *testing.T) {
+	cfg := defaultCfg()
+	cfg.SQMMinSafe = nil // not configured
+	in := safeInput()
+	in.Sensors.SkyQuality.SQM = 1.0 // terrible sky quality but no rule set
+	s := safety.Evaluate(cfg, in)
+	if !s.IsSafe {
+		t.Errorf("expected safe when SQM rule not configured, got: %v", s.Reasons)
+	}
+}
+
+// ---------- values are populated from sensors --------------------------------
+
+func TestEvaluatedState_AllValuesPopulated(t *testing.T) {
+	in := safeInput()
+	in.Sensors.Environment.Temperature = 15.5
+	in.Sensors.Environment.Humidity = 60.0
+	in.Sensors.Environment.Dewpoint = 8.0
+	in.Sensors.CloudConditions.CloudCoverPercent = 10.0
+	in.Sensors.CloudConditions.TemperatureDelta = -20.0
+	in.Sensors.CloudConditions.CorrectedDelta = -18.0
+
+	s := safety.Evaluate(defaultCfg(), in)
+
+	checks := []struct {
+		name string
+		got  float64
+		want float64
+	}{
+		{"Temperature", s.Values.Temperature, 15.5},
+		{"Humidity", s.Values.Humidity, 60.0},
+		{"Dewpoint", s.Values.Dewpoint, 8.0},
+		{"CloudCoverPercent", s.Values.CloudCoverPercent, 10.0},
+		{"TemperatureDelta", s.Values.TemperatureDelta, -20.0},
+		{"CorrectedDelta", s.Values.CorrectedDelta, -18.0},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("Values.%s: want %v, got %v", c.name, c.want, c.got)
+		}
+	}
+}

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,0 +1,88 @@
+package state_test
+
+import (
+	"testing"
+	"time"
+
+	"sqmeter-alpaca-safetymonitor/internal/state"
+)
+
+func TestNewHolder_ConnectedOnStartup(t *testing.T) {
+	h := state.NewHolder(true)
+	if !h.IsConnected() {
+		t.Error("expected connected=true after NewHolder(true)")
+	}
+}
+
+func TestNewHolder_DisconnectedOnStartup(t *testing.T) {
+	h := state.NewHolder(false)
+	if h.IsConnected() {
+		t.Error("expected connected=false after NewHolder(false)")
+	}
+}
+
+func TestSetConnected_Toggle(t *testing.T) {
+	h := state.NewHolder(false)
+	h.SetConnected(true)
+	if !h.IsConnected() {
+		t.Error("expected connected after SetConnected(true)")
+	}
+	h.SetConnected(false)
+	if h.IsConnected() {
+		t.Error("expected disconnected after SetConnected(false)")
+	}
+}
+
+func TestUpdate_Get_RoundTrip(t *testing.T) {
+	h := state.NewHolder(true)
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	ev := state.EvaluatedState{
+		IsSafe:                true,
+		Reasons:               []string{"r1"},
+		Warnings:              []string{"w1"},
+		LastPollUTC:           now,
+		LastSuccessfulPollUTC: now,
+		LastError:             "some error",
+	}
+	h.Update(ev)
+
+	got := h.Get()
+	if !got.IsSafe {
+		t.Error("IsSafe should be true")
+	}
+	if len(got.Reasons) != 1 || got.Reasons[0] != "r1" {
+		t.Errorf("Reasons: want [r1], got %v", got.Reasons)
+	}
+	if len(got.Warnings) != 1 || got.Warnings[0] != "w1" {
+		t.Errorf("Warnings: want [w1], got %v", got.Warnings)
+	}
+	if got.LastError != "some error" {
+		t.Errorf("LastError: want 'some error', got %q", got.LastError)
+	}
+}
+
+func TestGet_InitialState_IsSafeFalse(t *testing.T) {
+	h := state.NewHolder(true)
+	ev := h.Get()
+	if ev.IsSafe {
+		t.Error("initial IsSafe should be false (zero value)")
+	}
+}
+
+func TestUpdate_ReplacesState(t *testing.T) {
+	h := state.NewHolder(true)
+
+	h.Update(state.EvaluatedState{IsSafe: true})
+	if !h.Get().IsSafe {
+		t.Error("expected IsSafe=true after first update")
+	}
+
+	h.Update(state.EvaluatedState{IsSafe: false, Reasons: []string{"cloud"}})
+	got := h.Get()
+	if got.IsSafe {
+		t.Error("expected IsSafe=false after second update")
+	}
+	if len(got.Reasons) != 1 {
+		t.Errorf("expected 1 reason, got %d", len(got.Reasons))
+	}
+}


### PR DESCRIPTION
## Summary
- Moves polling logic out of the command entry point into `internal/poller`.
- Adds focused tests around polling, state updates, and safety evaluation behaviour.
- Keeps the command package focused on lifecycle and wiring.

## Validation
- `gofmt` on changed Go files
- `go test ./...`
- `go test ./... -race -count=1`