### PR TITLE
Add Alpaca, config, and web handler tests

### DIFF
--- a/internal/alpaca/handlers_extra_test.go
+++ b/internal/alpaca/handlers_extra_test.go
@@ -1,0 +1,253 @@
+package alpaca_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"sqmeter-alpaca-safetymonitor/internal/alpaca"
+	"sqmeter-alpaca-safetymonitor/internal/config"
+	"sqmeter-alpaca-safetymonitor/internal/state"
+)
+
+func doPUT(t *testing.T, h *alpaca.Handler, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	mux := http.NewServeMux()
+	h.Register(mux)
+	req := httptest.NewRequest(http.MethodPut, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	return w
+}
+
+// ---------- connected / connecting -------------------------------------------
+
+func TestGetConnected_True(t *testing.T) {
+	h := newTestHandler(true, safeState())
+	w := doGET(t, h, "/api/v1/safetymonitor/0/connected")
+	var resp alpaca.Response[bool]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if !resp.Value {
+		t.Error("expected Connected=true")
+	}
+}
+
+func TestGetConnected_False(t *testing.T) {
+	h := newTestHandler(false, safeState())
+	w := doGET(t, h, "/api/v1/safetymonitor/0/connected")
+	var resp alpaca.Response[bool]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.Value {
+		t.Error("expected Connected=false")
+	}
+}
+
+func TestGetConnecting_AlwaysFalse(t *testing.T) {
+	h := newTestHandler(true, safeState())
+	w := doGET(t, h, "/api/v1/safetymonitor/0/connecting")
+	var resp alpaca.Response[bool]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != 0 {
+		t.Fatalf("unexpected error: %v", resp.ErrorMessage)
+	}
+	if resp.Value {
+		t.Error("Connecting should always be false")
+	}
+}
+
+// ---------- metadata endpoints -----------------------------------------------
+
+func TestGetDeviceDescription_NonEmpty(t *testing.T) {
+	h := newTestHandler(true, safeState())
+	w := doGET(t, h, "/api/v1/safetymonitor/0/description")
+	var resp alpaca.Response[string]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.Value == "" {
+		t.Error("Description should not be empty")
+	}
+}
+
+func TestGetDriverInfo_NonEmpty(t *testing.T) {
+	h := newTestHandler(true, safeState())
+	w := doGET(t, h, "/api/v1/safetymonitor/0/driverinfo")
+	var resp alpaca.Response[string]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.Value == "" {
+		t.Error("DriverInfo should not be empty")
+	}
+}
+
+func TestGetDriverVersion_MatchesConstructorArg(t *testing.T) {
+	h := newTestHandler(true, safeState())
+	w := doGET(t, h, "/api/v1/safetymonitor/0/driverversion")
+	var resp alpaca.Response[string]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.Value != "0.1.0-test" {
+		t.Errorf("DriverVersion: want 0.1.0-test, got %q", resp.Value)
+	}
+}
+
+func TestGetInterfaceVersion_IsOne(t *testing.T) {
+	h := newTestHandler(true, safeState())
+	w := doGET(t, h, "/api/v1/safetymonitor/0/interfaceversion")
+	var resp alpaca.Response[int]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.Value != 1 {
+		t.Errorf("InterfaceVersion: want 1, got %d", resp.Value)
+	}
+}
+
+func TestGetName_NonEmpty(t *testing.T) {
+	h := newTestHandler(true, safeState())
+	w := doGET(t, h, "/api/v1/safetymonitor/0/name")
+	var resp alpaca.Response[string]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.Value == "" {
+		t.Error("Name should not be empty")
+	}
+}
+
+// ---------- DeviceState ------------------------------------------------------
+
+func TestGetDeviceState_ContainsRequiredItems(t *testing.T) {
+	h := newTestHandler(true, safeState())
+	w := doGET(t, h, "/api/v1/safetymonitor/0/devicestate")
+	var resp alpaca.Response[[]alpaca.DeviceStateItem]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != 0 {
+		t.Fatalf("unexpected error: %v", resp.ErrorMessage)
+	}
+	names := map[string]bool{}
+	for _, item := range resp.Value {
+		names[item.Name] = true
+	}
+	for _, required := range []string{"IsSafe", "TimeStamp"} {
+		if !names[required] {
+			t.Errorf("DeviceState missing item %q, got: %v", required, resp.Value)
+		}
+	}
+}
+
+// ---------- PUT connect / disconnect -----------------------------------------
+
+func TestPutConnect_SetsConnected(t *testing.T) {
+	cfgHolder := config.NewHolder(config.Defaults(), "")
+	holder := state.NewHolder(false)
+	h := alpaca.New(cfgHolder, holder, "uuid", "0.1.0", nil)
+
+	w := doPUT(t, h, "/api/v1/safetymonitor/0/connect", "ClientID=1&ClientTransactionID=1")
+	var resp alpaca.VoidResponse
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != 0 {
+		t.Errorf("unexpected error: %v", resp.ErrorMessage)
+	}
+	if !holder.IsConnected() {
+		t.Error("expected connected after PUT /connect")
+	}
+}
+
+func TestPutDisconnect_SetsDisconnected(t *testing.T) {
+	cfgHolder := config.NewHolder(config.Defaults(), "")
+	holder := state.NewHolder(true)
+	h := alpaca.New(cfgHolder, holder, "uuid", "0.1.0", nil)
+
+	w := doPUT(t, h, "/api/v1/safetymonitor/0/disconnect", "ClientID=1&ClientTransactionID=1")
+	var resp alpaca.VoidResponse
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != 0 {
+		t.Errorf("unexpected error: %v", resp.ErrorMessage)
+	}
+	if holder.IsConnected() {
+		t.Error("expected disconnected after PUT /disconnect")
+	}
+}
+
+func TestPutConnected_SetFalse(t *testing.T) {
+	cfgHolder := config.NewHolder(config.Defaults(), "")
+	holder := state.NewHolder(true)
+	h := alpaca.New(cfgHolder, holder, "uuid", "0.1.0", nil)
+
+	w := doPUT(t, h, "/api/v1/safetymonitor/0/connected",
+		"Connected=false&ClientID=1&ClientTransactionID=1")
+	var resp alpaca.VoidResponse
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != 0 {
+		t.Errorf("unexpected error: %v", resp.ErrorMessage)
+	}
+	if holder.IsConnected() {
+		t.Error("expected disconnected after PUT Connected=false")
+	}
+}
+
+func TestPutConnected_InvalidValue_ReturnsError(t *testing.T) {
+	h := newTestHandler(true, safeState())
+	w := doPUT(t, h, "/api/v1/safetymonitor/0/connected",
+		"Connected=maybe&ClientID=1&ClientTransactionID=1")
+	var resp alpaca.VoidResponse
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber == 0 {
+		t.Error("expected non-zero error for invalid Connected value")
+	}
+}
+
+// ---------- PUT action (refresh) ---------------------------------------------
+
+func TestPutAction_Refresh_CallsRefreshFn(t *testing.T) {
+	called := false
+	cfgHolder := config.NewHolder(config.Defaults(), "")
+	holder := state.NewHolder(true)
+	holder.Update(state.EvaluatedState{
+		IsSafe:                true,
+		Reasons:               []string{},
+		Warnings:              []string{},
+		LastSuccessfulPollUTC: time.Now(),
+		LastPollUTC:           time.Now(),
+	})
+	h := alpaca.New(cfgHolder, holder, "uuid", "0.1.0", func(_ context.Context) {
+		called = true
+	})
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/safetymonitor/0/action",
+		strings.NewReader("Action=refresh&ClientID=1&ClientTransactionID=1"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	var resp alpaca.Response[string]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != 0 {
+		t.Fatalf("unexpected error: %v", resp.ErrorMessage)
+	}
+	if !called {
+		t.Error("expected refresh function to be called")
+	}
+}
+
+// ---------- not-implemented commands -----------------------------------------
+
+func TestPutCommandBool_NotImplemented(t *testing.T) {
+	h := newTestHandler(true, safeState())
+	w := doPUT(t, h, "/api/v1/safetymonitor/0/commandbool", "Command=foo")
+	var resp alpaca.VoidResponse
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != alpaca.ErrNotImplemented {
+		t.Errorf("want ErrNotImplemented (%d), got %d", alpaca.ErrNotImplemented, resp.ErrorNumber)
+	}
+}
+
+func TestPutCommandString_NotImplemented(t *testing.T) {
+	h := newTestHandler(true, safeState())
+	w := doPUT(t, h, "/api/v1/safetymonitor/0/commandstring", "Command=foo")
+	var resp alpaca.VoidResponse
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != alpaca.ErrNotImplemented {
+		t.Errorf("want ErrNotImplemented (%d), got %d", alpaca.ErrNotImplemented, resp.ErrorNumber)
+	}
+}

--- a/internal/config/config_extra_test.go
+++ b/internal/config/config_extra_test.go
@@ -1,0 +1,211 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"sqmeter-alpaca-safetymonitor/internal/config"
+)
+
+// ---------- NeedsRestart -----------------------------------------------------
+
+func TestNeedsRestart_SameConfig(t *testing.T) {
+	a := config.Defaults()
+	b := *a
+	if config.NeedsRestart(a, &b) {
+		t.Error("identical config should not require restart")
+	}
+}
+
+func TestNeedsRestart_URLChange(t *testing.T) {
+	a := config.Defaults()
+	b := *a
+	b.SQMeterBaseURL = "http://other.local"
+	if config.NeedsRestart(a, &b) {
+		t.Error("URL-only change should not require restart")
+	}
+}
+
+func TestNeedsRestart_HTTPPortChange(t *testing.T) {
+	a := config.Defaults()
+	b := *a
+	b.AlpacaHTTPPort = 22222
+	if !config.NeedsRestart(a, &b) {
+		t.Error("HTTP port change should require restart")
+	}
+}
+
+func TestNeedsRestart_DiscoveryPortChange(t *testing.T) {
+	a := config.Defaults()
+	b := *a
+	b.AlpacaDiscoveryPort = 33333
+	if !config.NeedsRestart(a, &b) {
+		t.Error("discovery port change should require restart")
+	}
+}
+
+func TestNeedsRestart_BindChange(t *testing.T) {
+	a := config.Defaults()
+	b := *a
+	b.AlpacaHTTPBind = "0.0.0.0"
+	if !config.NeedsRestart(a, &b) {
+		t.Error("bind address change should require restart")
+	}
+}
+
+// ---------- IsWideOpen -------------------------------------------------------
+
+func TestIsWideOpen_Loopback(t *testing.T) {
+	for _, addr := range []string{"127.0.0.1", "localhost", "::1"} {
+		if config.IsWideOpen(addr) {
+			t.Errorf("IsWideOpen(%q) should be false (loopback)", addr)
+		}
+	}
+}
+
+func TestIsWideOpen_NonLoopback(t *testing.T) {
+	for _, addr := range []string{"0.0.0.0", "192.168.1.1", ""} {
+		if !config.IsWideOpen(addr) {
+			t.Errorf("IsWideOpen(%q) should be true", addr)
+		}
+	}
+}
+
+// ---------- Holder -----------------------------------------------------------
+
+func TestHolder_Get_ReturnsInitialDefaults(t *testing.T) {
+	h := config.NewHolder(config.Defaults(), "")
+	cfg := h.Get()
+	if cfg.AlpacaHTTPPort != 11111 {
+		t.Errorf("want port 11111, got %d", cfg.AlpacaHTTPPort)
+	}
+}
+
+func TestHolder_Path(t *testing.T) {
+	h := config.NewHolder(config.Defaults(), "/tmp/test.json")
+	if h.Path() != "/tmp/test.json" {
+		t.Errorf("Path(): want /tmp/test.json, got %q", h.Path())
+	}
+}
+
+func TestHolder_Update_Valid(t *testing.T) {
+	h := config.NewHolder(config.Defaults(), "")
+	updated := *h.Get()
+	updated.LogLevel = "debug"
+	if err := h.Update(&updated); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if h.Get().LogLevel != "debug" {
+		t.Errorf("LogLevel not updated: got %q", h.Get().LogLevel)
+	}
+}
+
+func TestHolder_Update_InvalidRejected(t *testing.T) {
+	h := config.NewHolder(config.Defaults(), "")
+	original := h.Get().LogLevel
+	invalid := *h.Get()
+	invalid.ManualOverride = "not_valid"
+	if err := h.Update(&invalid); err == nil {
+		t.Error("expected error for invalid ManualOverride")
+	}
+	if h.Get().LogLevel != original {
+		t.Error("config should not be mutated after a rejected update")
+	}
+}
+
+func TestHolder_Update_PersistsToFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	h := config.NewHolder(config.Defaults(), path)
+
+	updated := *h.Get()
+	updated.LogLevel = "warn"
+	if err := h.Update(&updated); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("config file not written: %v", err)
+	}
+	if !strings.Contains(string(data), "warn") {
+		t.Errorf("expected 'warn' in persisted config, got: %s", data)
+	}
+}
+
+func TestHolder_Update_NoPersistWhenPathEmpty(t *testing.T) {
+	h := config.NewHolder(config.Defaults(), "")
+	updated := *h.Get()
+	updated.LogLevel = "debug"
+	// Should not error even with no path
+	if err := h.Update(&updated); err != nil {
+		t.Fatalf("Update with no path: %v", err)
+	}
+}
+
+func TestSaveDefault(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "defaults.json")
+	if err := config.SaveDefault(path); err != nil {
+		t.Fatalf("SaveDefault: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("file not created: %v", err)
+	}
+	if !strings.Contains(string(data), "sqmeter.local") {
+		t.Errorf("expected default SQMeter URL in output, got: %s", data)
+	}
+}
+
+// ---------- validate edge cases ----------------------------------------------
+
+func TestLoad_InvalidPortRange(t *testing.T) {
+	t.Setenv("ALPACA_HTTP_PORT", "99999")
+	_, err := config.Load("")
+	if err == nil {
+		t.Error("expected error for port 99999 (out of range)")
+	}
+}
+
+func TestLoad_ZeroPort(t *testing.T) {
+	t.Setenv("ALPACA_HTTP_PORT", "0")
+	_, err := config.Load("")
+	if err == nil {
+		t.Error("expected error for port 0")
+	}
+}
+
+func TestLoad_StaleAfterLessThanPollInterval(t *testing.T) {
+	t.Setenv("POLL_INTERVAL_SECONDS", "60")
+	t.Setenv("STALE_AFTER_SECONDS", "10")
+	_, err := config.Load("")
+	if err == nil {
+		t.Error("expected error when STALE_AFTER_SECONDS < POLL_INTERVAL_SECONDS")
+	}
+}
+
+func TestLoad_ParseBoolEnv(t *testing.T) {
+	for _, v := range []string{"true", "1", "yes", "on", "TRUE", "YES"} {
+		t.Setenv("FAIL_CLOSED", v)
+		cfg, err := config.Load("")
+		if err != nil {
+			t.Fatalf("Load (FAIL_CLOSED=%q): %v", v, err)
+		}
+		if !cfg.FailClosed {
+			t.Errorf("FAIL_CLOSED=%q should parse as true", v)
+		}
+	}
+	for _, v := range []string{"false", "0", "no", "off", "FALSE"} {
+		t.Setenv("FAIL_CLOSED", v)
+		cfg, err := config.Load("")
+		if err != nil {
+			t.Fatalf("Load (FAIL_CLOSED=%q): %v", v, err)
+		}
+		if cfg.FailClosed {
+			t.Errorf("FAIL_CLOSED=%q should parse as false", v)
+		}
+	}
+}

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -1,0 +1,284 @@
+package web_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"sqmeter-alpaca-safetymonitor/internal/config"
+	"sqmeter-alpaca-safetymonitor/internal/state"
+	"sqmeter-alpaca-safetymonitor/internal/web"
+)
+
+func newTestWebHandler(t *testing.T, connected bool, ev state.EvaluatedState) (*web.Handler, *config.Holder, *state.Holder) {
+	t.Helper()
+	cfgHolder := config.NewHolder(config.Defaults(), "")
+	holder := state.NewHolder(connected)
+	holder.Update(ev)
+	h, err := web.New(cfgHolder, holder)
+	if err != nil {
+		t.Fatalf("web.New: %v", err)
+	}
+	return h, cfgHolder, holder
+}
+
+func safeEv() state.EvaluatedState {
+	now := time.Now().UTC()
+	return state.EvaluatedState{
+		IsSafe:                true,
+		Reasons:               []string{},
+		Warnings:              []string{},
+		LastPollUTC:           now,
+		LastSuccessfulPollUTC: now,
+	}
+}
+
+func unsafeEv() state.EvaluatedState {
+	ev := safeEv()
+	ev.IsSafe = false
+	ev.Reasons = []string{"cloud cover 90% >= unsafe threshold 80%"}
+	return ev
+}
+
+func serve(t *testing.T, h *web.Handler, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	mux := http.NewServeMux()
+	h.Register(mux)
+	var req *http.Request
+	if body != "" {
+		req = httptest.NewRequest(method, path, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	} else {
+		req = httptest.NewRequest(method, path, nil)
+	}
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	return w
+}
+
+// ---------- /health ----------------------------------------------------------
+
+func TestHealth_OKWhenSafe(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	w := serve(t, h, http.MethodGet, "/health", "")
+	if w.Code != http.StatusOK {
+		t.Errorf("health: want 200, got %d", w.Code)
+	}
+	var body map[string]any
+	json.NewDecoder(w.Body).Decode(&body)
+	if body["status"] != "ok" {
+		t.Errorf("health status: want ok, got %q", body["status"])
+	}
+}
+
+func TestHealth_UnsafeWhenIsSafeFalse(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, unsafeEv())
+	w := serve(t, h, http.MethodGet, "/health", "")
+	if w.Code != http.StatusOK {
+		t.Errorf("health: want 200 even when unsafe, got %d", w.Code)
+	}
+	var body map[string]any
+	json.NewDecoder(w.Body).Decode(&body)
+	if body["status"] != "unsafe" {
+		t.Errorf("health status: want unsafe, got %q", body["status"])
+	}
+}
+
+func TestHealth_ServiceUnavailableWhenDisconnected(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, false, safeEv())
+	w := serve(t, h, http.MethodGet, "/health", "")
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("health: want 503 when disconnected, got %d", w.Code)
+	}
+	var body map[string]any
+	json.NewDecoder(w.Body).Decode(&body)
+	if body["status"] != "disconnected" {
+		t.Errorf("health status: want disconnected, got %q", body["status"])
+	}
+}
+
+// ---------- /status.json -----------------------------------------------------
+
+func TestStatusJSON_ValidJSON(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	w := serve(t, h, http.MethodGet, "/status.json", "")
+	if w.Code != http.StatusOK {
+		t.Errorf("status.json: want 200, got %d", w.Code)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("status.json: invalid JSON: %v", err)
+	}
+}
+
+func TestStatusJSON_IsSafeField(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	w := serve(t, h, http.MethodGet, "/status.json", "")
+	var body map[string]any
+	json.NewDecoder(w.Body).Decode(&body)
+	if v, ok := body["isSafe"]; !ok || v != true {
+		t.Errorf("status.json: expected isSafe=true, got %v (present=%v)", v, ok)
+	}
+}
+
+func TestStatusJSON_ReflectsUnsafeState(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, unsafeEv())
+	w := serve(t, h, http.MethodGet, "/status.json", "")
+	var body map[string]any
+	json.NewDecoder(w.Body).Decode(&body)
+	if body["isSafe"] != false {
+		t.Errorf("status.json: expected isSafe=false for unsafe state, got %v", body["isSafe"])
+	}
+}
+
+// ---------- /  (dashboard) ---------------------------------------------------
+
+func TestDashboard_Renders200(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	w := serve(t, h, http.MethodGet, "/", "")
+	if w.Code != http.StatusOK {
+		t.Errorf("dashboard: want 200, got %d", w.Code)
+	}
+	ct := w.Header().Get("Content-Type")
+	if !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("dashboard Content-Type: want text/html, got %q", ct)
+	}
+}
+
+func TestDashboard_AliasedFromStatus(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	w := serve(t, h, http.MethodGet, "/status", "")
+	if w.Code != http.StatusOK {
+		t.Errorf("/status: want 200, got %d", w.Code)
+	}
+}
+
+// ---------- /setup -----------------------------------------------------------
+
+func TestGetSetup_Renders200(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	w := serve(t, h, http.MethodGet, "/setup", "")
+	if w.Code != http.StatusOK {
+		t.Errorf("GET /setup: want 200, got %d", w.Code)
+	}
+	ct := w.Header().Get("Content-Type")
+	if !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("GET /setup Content-Type: want text/html, got %q", ct)
+	}
+}
+
+func TestPostSetup_ValidSubmit_Redirects(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	form := url.Values{}
+	form.Set("SQMETER_BASE_URL", "http://newsqm.local")
+	form.Set("ALPACA_HTTP_BIND", "127.0.0.1")
+	form.Set("ALPACA_HTTP_PORT", "11111")
+	form.Set("ALPACA_DISCOVERY_PORT", "32227")
+	form.Set("POLL_INTERVAL_SECONDS", "5")
+	form.Set("STALE_AFTER_SECONDS", "30")
+	form.Set("FAIL_CLOSED", "true")
+	form.Set("CONNECTED_ON_STARTUP", "true")
+	form.Set("CLOUD_COVER_UNSAFE_PERCENT", "80")
+	form.Set("CLOUD_COVER_CAUTION_PERCENT", "50")
+	form.Set("MANUAL_OVERRIDE", "auto")
+	form.Set("LOG_LEVEL", "info")
+
+	w := serve(t, h, http.MethodPost, "/setup", form.Encode())
+	if w.Code != http.StatusSeeOther {
+		t.Errorf("POST /setup: want 303 redirect, got %d", w.Code)
+	}
+	loc := w.Header().Get("Location")
+	if !strings.Contains(loc, "/setup") {
+		t.Errorf("POST /setup redirect: expected /setup, got %q", loc)
+	}
+}
+
+func TestPostSetup_UpdatesConfig(t *testing.T) {
+	h, cfgHolder, _ := newTestWebHandler(t, true, safeEv())
+	form := url.Values{}
+	// Only set the fields that differ from defaults
+	form.Set("SQMETER_BASE_URL", "http://changed.local")
+	form.Set("ALPACA_HTTP_BIND", "127.0.0.1")
+	form.Set("ALPACA_HTTP_PORT", "11111")
+	form.Set("ALPACA_DISCOVERY_PORT", "32227")
+	form.Set("POLL_INTERVAL_SECONDS", "5")
+	form.Set("STALE_AFTER_SECONDS", "30")
+	form.Set("FAIL_CLOSED", "true")
+	form.Set("CONNECTED_ON_STARTUP", "true")
+	form.Set("CLOUD_COVER_UNSAFE_PERCENT", "80")
+	form.Set("CLOUD_COVER_CAUTION_PERCENT", "50")
+	form.Set("MANUAL_OVERRIDE", "auto")
+	form.Set("LOG_LEVEL", "info")
+
+	serve(t, h, http.MethodPost, "/setup", form.Encode())
+
+	if cfgHolder.Get().SQMeterBaseURL != "http://changed.local" {
+		t.Errorf("config not updated: SQMeterBaseURL = %q", cfgHolder.Get().SQMeterBaseURL)
+	}
+}
+
+// ---------- /config.json API -------------------------------------------------
+
+func TestGetConfigJSON_ValidJSON(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	w := serve(t, h, http.MethodGet, "/config.json", "")
+	if w.Code != http.StatusOK {
+		t.Errorf("GET /config.json: want 200, got %d", w.Code)
+	}
+	var cfg map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&cfg); err != nil {
+		t.Fatalf("GET /config.json: invalid JSON: %v", err)
+	}
+	if _, ok := cfg["SQMETER_BASE_URL"]; !ok {
+		t.Error("GET /config.json: expected SQMETER_BASE_URL field")
+	}
+}
+
+func TestPutConfigJSON_UpdatesConfig(t *testing.T) {
+	h, cfgHolder, _ := newTestWebHandler(t, true, safeEv())
+	body := `{"SQMETER_BASE_URL":"http://put-updated.local","LOG_LEVEL":"debug"}`
+
+	w := serve(t, h, http.MethodPut, "/config.json", body)
+	if w.Code != http.StatusOK {
+		t.Errorf("PUT /config.json: want 200, got %d — body: %s", w.Code, w.Body.String())
+	}
+
+	if cfgHolder.Get().SQMeterBaseURL != "http://put-updated.local" {
+		t.Errorf("config not updated via PUT: SQMeterBaseURL = %q", cfgHolder.Get().SQMeterBaseURL)
+	}
+}
+
+func TestPutConfigJSON_InvalidJSON_Returns400(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	w := serve(t, h, http.MethodPut, "/config.json", "{not valid json{{")
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("PUT /config.json invalid JSON: want 400, got %d", w.Code)
+	}
+}
+
+func TestPutConfigJSON_InvalidConfig_Returns422(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	body := `{"MANUAL_OVERRIDE":"completely_wrong"}`
+	w := serve(t, h, http.MethodPut, "/config.json", body)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("PUT /config.json invalid config: want 422, got %d", w.Code)
+	}
+}
+
+func TestPutConfigJSON_NeedsRestart_FlaggedInResponse(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	body := `{"ALPACA_HTTP_PORT":22222}`
+	w := serve(t, h, http.MethodPut, "/config.json", body)
+
+	var resp struct {
+		NeedsRestart bool `json:"needsRestart"`
+	}
+	json.NewDecoder(w.Body).Decode(&resp)
+	if !resp.NeedsRestart {
+		t.Error("expected needsRestart=true when HTTP port changes")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds coverage for Alpaca handler responses.
- Adds config validation, load, and save coverage.
- Adds web handler tests for setup and status behaviour.

## Validation
- `gofmt` on changed Go files
- `go test ./...`
- `go test ./internal/alpaca ./internal/config ./internal/web -count=1`