### PR TITLE
Add ASCOM ConformU conformance checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,3 +83,45 @@ jobs:
         with:
           name: binaries
           path: dist/
+
+  conformance:
+    name: ASCOM Conformance
+    runs-on: ubuntu-latest
+    needs: lint-and-test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build service
+        run: |
+          go build \
+            -ldflags "-X main.version=ci -X main.commit=$GITHUB_SHA -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            -o bin/sqmeter-alpaca-safetymonitor \
+            ./cmd/sqmeter-alpaca-safetymonitor
+
+      - name: Download ConformU
+        run: |
+          mkdir -p .conform
+          curl -sSL \
+            "https://github.com/ASCOMInitiative/ConformU/releases/download/v4.3.0/conformu.linux-x64.tar.xz" \
+            | tar -xJ -C .conform
+          chmod +x .conform/conformu
+
+      - name: Run conformance test
+        run: CONFORM_BIN=.conform/conformu bash scripts/conform.sh
+
+      - name: Upload conformance report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: conformance-report
+          path: |
+            ConformU/
+            *.log

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ dist/
 
 # UUID state file (generated at runtime)
 device-uuid.txt
+
+# ConformU downloaded binary (Linux)
+.conform/

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,13 @@ DATE     ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS  := -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)"
 MAIN     := ./cmd/$(BINARY)
 
+CONFORM_VERSION  := v4.3.0
+CONFORM_DIR      := .conform
+CONFORM_LINUX_URL := https://github.com/ASCOMInitiative/ConformU/releases/download/$(CONFORM_VERSION)/conformu.linux-x64.tar.xz
+
 .PHONY: all build build-windows build-linux build-linux-arm64 test lint fmt vet clean run \
-        service-install service-start service-stop service-uninstall service-status
+        service-install service-start service-stop service-uninstall service-status \
+        conform conform-download
 
 all: build
 
@@ -62,3 +67,15 @@ service-uninstall:
 
 service-status:
 	./bin/$(BINARY) --service status
+
+# Download ConformU for Linux (CI / Linux dev machines).
+# On macOS, install ConformU from https://github.com/ASCOMInitiative/ConformU/releases
+conform-download:
+	@mkdir -p $(CONFORM_DIR)
+	curl -sSL "$(CONFORM_LINUX_URL)" | tar -xJ -C $(CONFORM_DIR)
+	chmod +x $(CONFORM_DIR)/conformu
+
+# Run ASCOM ConformU conformance test against the service + mock SQMeter.
+# Set CONFORM_BIN to override the binary path (auto-detected otherwise).
+conform: build
+	bash scripts/conform.sh

--- a/scripts/conform.sh
+++ b/scripts/conform.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Run an ASCOM ConformU conformance test against the service backed by a mock SQMeter.
+#
+# On Linux the conformu binary runs headlessly (CLI mode). On macOS the app is
+# GUI-only, so this script starts the services and prints the device URL to paste
+# into the ConformU browser UI, then waits until you press Ctrl-C.
+#
+# Usage:
+#   bash scripts/conform.sh
+#   CONFORM_BIN=/path/to/conformu bash scripts/conform.sh   # override binary
+#
+# Environment variables (all optional):
+#   CONFORM_BIN   path to the conformu binary (auto-detected)
+#   SQM_PORT      port for the mock SQMeter server  (default: 18080)
+#   ALPACA_PORT   port for the Alpaca service        (default: 11111)
+#   SERVICE_BIN   path to the built service binary   (default: bin/sqmeter-alpaca-safetymonitor)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SQM_PORT="${SQM_PORT:-18080}"
+ALPACA_PORT="${ALPACA_PORT:-11111}"
+SERVICE_BIN="${SERVICE_BIN:-${REPO_ROOT}/bin/sqmeter-alpaca-safetymonitor}"
+IS_MACOS=false
+[[ "$(uname)" == "Darwin" ]] && IS_MACOS=true
+
+if [ ! -x "$SERVICE_BIN" ]; then
+    echo "error: service binary not found at $SERVICE_BIN — run 'make build' first" >&2
+    exit 1
+fi
+
+# Locate conformu binary (Linux/CI only — macOS uses the GUI app)
+if ! $IS_MACOS; then
+    if [ -z "${CONFORM_BIN:-}" ]; then
+        if command -v conformu &>/dev/null; then
+            CONFORM_BIN="conformu"
+        elif [ -x "${REPO_ROOT}/.conform/conformu" ]; then
+            CONFORM_BIN="${REPO_ROOT}/.conform/conformu"
+        else
+            echo "error: conformu not found — set CONFORM_BIN or run 'make conform-download'" >&2
+            exit 1
+        fi
+    fi
+fi
+
+SQM_PID=""
+SVC_PID=""
+
+cleanup() {
+    [ -n "$SQM_PID" ] && kill "$SQM_PID" 2>/dev/null || true
+    [ -n "$SVC_PID" ] && kill "$SVC_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Start mock SQMeter
+python3 "$REPO_ROOT/scripts/mock-sqm.py" "$SQM_PORT" &
+SQM_PID=$!
+
+# Start Alpaca service pointing at the mock with fast polling.
+# FAIL_CLOSED=false so the service reports safe even before the first poll lands.
+SQMETER_BASE_URL="http://127.0.0.1:${SQM_PORT}" \
+ALPACA_HTTP_BIND="127.0.0.1" \
+ALPACA_HTTP_PORT="$ALPACA_PORT" \
+ALPACA_DISCOVERY_PORT=32227 \
+POLL_INTERVAL_SECONDS=1 \
+STALE_AFTER_SECONDS=10 \
+CONNECTED_ON_STARTUP=true \
+FAIL_CLOSED=false \
+  "$SERVICE_BIN" &
+SVC_PID=$!
+
+# Wait for the Alpaca management endpoint to respond
+echo "waiting for Alpaca service on port ${ALPACA_PORT}..."
+READY=0
+for i in $(seq 1 30); do
+    if curl -sf "http://127.0.0.1:${ALPACA_PORT}/management/apiversions" >/dev/null 2>&1; then
+        READY=1
+        break
+    fi
+    sleep 1
+done
+if [ "$READY" -eq 0 ]; then
+    echo "error: service did not become ready within 30s" >&2
+    exit 1
+fi
+
+# Trigger an immediate SQMeter poll so IsSafe is populated before ConformU queries it.
+curl -sf -X PUT \
+    -d "Action=refresh&ClientID=0&ClientTransactionID=1" \
+    "http://127.0.0.1:${ALPACA_PORT}/api/v1/safetymonitor/0/action" >/dev/null
+
+DEVICE_URL="http://127.0.0.1:${ALPACA_PORT}/api/v1/safetymonitor/0"
+
+if $IS_MACOS; then
+    # ConformU on macOS is a GUI-only app. UDP discovery doesn't work on loopback,
+    # so enter the device URL directly in the ConformU interface.
+    echo ""
+    echo "Services are ready."
+    echo ""
+    echo "  Mock SQMeter : http://127.0.0.1:${SQM_PORT}"
+    echo "  Alpaca device: ${DEVICE_URL}"
+    echo ""
+    echo "In ConformU:"
+    echo "  1. Select 'Alpaca Device' and choose device type 'SafetyMonitor'"
+    echo "  2. Enter the Alpaca URL manually: ${DEVICE_URL}"
+    echo "  3. Click 'Start Conform'"
+    echo ""
+    echo "Press Ctrl-C to stop the services when done."
+    wait
+else
+    echo "running ConformU conformance test..."
+    echo "device: ${DEVICE_URL}"
+    echo ""
+    "$CONFORM_BIN" conformance "$DEVICE_URL"
+fi

--- a/scripts/mock-sqm.py
+++ b/scripts/mock-sqm.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Minimal HTTP server that mimics the SQMeter ESP32 REST API using testdata."""
+import sys
+import os
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+BASE = os.path.join(os.path.dirname(__file__), '..', 'testdata', 'sqm')
+
+with open(os.path.join(BASE, 'sensors.json'), 'rb') as f:
+    SENSORS = f.read()
+with open(os.path.join(BASE, 'status.json'), 'rb') as f:
+    STATUS = f.read()
+
+ROUTES = {
+    '/api/sensors': SENSORS,
+    '/api/status': STATUS,
+}
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        body = ROUTES.get(self.path)
+        if body is None:
+            self.send_response(404)
+            self.end_headers()
+            return
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, fmt, *args):  # silence request logs
+        pass
+
+
+port = int(sys.argv[1]) if len(sys.argv) > 1 else 18080
+print(f'mock-sqm listening on 127.0.0.1:{port}', flush=True)
+HTTPServer(('127.0.0.1', port), Handler).serve_forever()


### PR DESCRIPTION
## Summary
- Adds a mock SQMeter service and conformance runner script.
- Adds a CI job to run ASCOM ConformU against the Alpaca SafetyMonitor bridge.
- Uploads conformance reports as workflow artifacts.

## Validation
- `bash -n scripts/conform.sh`
- `python3 -m py_compile scripts/mock-sqm.py`
- `go test ./...`

`make conform` was not run locally because ConformU execution is intended for Linux CI or a local ConformU install.