### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint-and-test:
     name: Lint and Test


### PR DESCRIPTION
Potential fix for [https://github.com/DeanJ87/SQMeter-Safety-Monitor/security/code-scanning/1](https://github.com/DeanJ87/SQMeter-Safety-Monitor/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least-privilege token access unless overridden.  
Best minimal fix for current functionality: set:

- `contents: read`

This supports checkout and read-only repository access used by lint/test/build flows. No job in the shown workflow needs write scopes.

Edit region: near the top of `.github/workflows/ci.yml`, after the `on:` trigger block and before `jobs:`.

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
