### PR TITLE
Add coverage reporting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,20 @@ jobs:
         run: go test ./... -race -count=1
 
       - name: Test (coverage)
-        run: go test ./... -coverprofile=coverage.out
+        run: |
+          # Exclude cmd/ — it is process-lifecycle wiring tested via integration,
+          # not unit tests. Coverage is measured over internal/ packages only.
+          go test $(go list ./... | grep -v '/cmd/') \
+            -coverprofile=coverage.out -covermode=atomic
+          go tool cover -func=coverage.out | tail -1
 
-      - name: Upload coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.out
+          fail_ci_if_error: false
+
+      - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:
           name: coverage

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # sqmeter-alpaca-safetymonitor
 
+[![CI](https://github.com/DeanJ87/SQMeter-Safety-Monitor/actions/workflows/ci.yml/badge.svg)](https://github.com/DeanJ87/SQMeter-Safety-Monitor/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/DeanJ87/SQMeter-Safety-Monitor/branch/main/graph/badge.svg)](https://codecov.io/gh/DeanJ87/SQMeter-Safety-Monitor)
+
 A standalone **ASCOM Alpaca SafetyMonitor** bridge for the [SQMeter ESP32](https://deanj87.github.io/SQMeter/) sky-quality sensor.
 
 Runs as a single `.exe` on your N.I.N.A. Windows machine.  No ASCOM COM drivers, no registration, no Visual Studio templates — pure Alpaca over HTTP/UDP.


### PR DESCRIPTION
## Summary
- Generates an internal package coverage profile.
- Uploads coverage as a workflow artifact.
- Sends coverage to Codecov without failing CI if Codecov upload is unavailable.
- Adds CI and Codecov README badges.

## Validation
- `go test $(go list ./... | grep -v '/cmd/') -coverprofile=coverage.out -covermode=atomic`\n- `go tool cover -func=coverage.out | tail -1`