### PR TITLE
Build Windows installer during releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   release:
-    name: Release
+    name: Release (binaries)
     runs-on: ubuntu-latest
 
     steps:
@@ -37,3 +37,48 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+
+  installer-windows:
+    name: Windows Installer
+    runs-on: windows-latest
+    needs: release
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build Windows binary
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          go build \
+            -ldflags "-X main.version=${VERSION} -X main.commit=${GITHUB_SHA} -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            -o installer/bin/sqmeter-alpaca-safetymonitor.exe \
+            ./cmd/sqmeter-alpaca-safetymonitor
+
+      - name: Install Inno Setup
+        run: choco install innosetup --no-progress -y
+
+      - name: Build installer
+        shell: cmd
+        run: |
+          set VERSION=%GITHUB_REF_NAME%
+          set VERSION=%VERSION:v=%
+          "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DAppVersion=%VERSION% installer\setup.iss
+
+      - name: Upload installer to release
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
+          gh release upload "${TAG}" \
+            "installer/Output/sqmeter-alpaca-safetymonitor-setup-${VERSION}.exe" \
+            --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ dist/
 
 # UUID state file (generated at runtime)
 device-uuid.txt
+
+# Installer build artefacts
+installer/bin/
+installer/Output/

--- a/installer/setup.iss
+++ b/installer/setup.iss
@@ -1,0 +1,71 @@
+; SQMeter Alpaca SafetyMonitor - Inno Setup installer script
+; Build with: ISCC.exe /DAppVersion=1.2.3 setup.iss
+
+#ifndef AppVersion
+  #define AppVersion "dev"
+#endif
+
+#define AppName      "SQMeter Alpaca SafetyMonitor"
+#define AppPublisher "DeanJ87"
+#define AppURL       "https://github.com/DeanJ87/SQMeter-Safety-Monitor"
+#define ServiceName  "SQMeterAlpacaSafetyMonitor"
+#define ExeName      "sqmeter-alpaca-safetymonitor.exe"
+#define SetupBase    "sqmeter-alpaca-safetymonitor-setup"
+
+[Setup]
+AppId={{E3A7C2B1-4F8D-4E2A-9C3B-1D5F7A8E0B2C}
+AppName={#AppName}
+AppVersion={#AppVersion}
+AppPublisher={#AppPublisher}
+AppPublisherURL={#AppURL}
+AppSupportURL={#AppURL}/issues
+AppUpdatesURL={#AppURL}/releases
+DefaultDirName={autopf}\{#AppName}
+DefaultGroupName={#AppName}
+DisableProgramGroupPage=yes
+PrivilegesRequired=admin
+OutputDir=Output
+OutputBaseFilename={#SetupBase}-{#AppVersion}
+Compression=lzma
+SolidCompression=yes
+WizardStyle=modern
+; Require Windows 10 or later (needed for modern TLS and IPv6 UDP)
+MinVersion=10.0
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Files]
+; Main binary - placed in the install directory
+Source: "bin\{#ExeName}"; DestDir: "{app}"; Flags: ignoreversion
+
+[Run]
+; Install the Windows service (registered against the installed exe path)
+Filename: "{app}\{#ExeName}"; Parameters: "--service install"; \
+  Flags: runhidden waituntilterminated; \
+  StatusMsg: "Installing service..."
+
+; Start the service so it is immediately available
+Filename: "{app}\{#ExeName}"; Parameters: "--service start"; \
+  Flags: runhidden waituntilterminated; \
+  StatusMsg: "Starting service..."
+
+; Open the configuration page in the default browser (skipped in silent installs)
+Filename: "http://localhost:11111/setup"; \
+  Flags: shellexec nowait; \
+  Description: "Open configuration page in browser"; \
+  Check: not WizardSilent
+
+[UninstallRun]
+; Stop then uninstall the service before removing files
+Filename: "{app}\{#ExeName}"; Parameters: "--service stop"; \
+  Flags: runhidden waituntilterminated
+Filename: "{app}\{#ExeName}"; Parameters: "--service uninstall"; \
+  Flags: runhidden waituntilterminated
+
+[Icons]
+Name: "{group}\Configuration"; \
+  Filename: "{app}\{#ExeName}"; \
+  Parameters: ""; \
+  Comment: "Open SQMeter SafetyMonitor configuration (opens browser)"
+Name: "{group}\Uninstall {#AppName}"; Filename: "{uninstallexe}"


### PR DESCRIPTION
## Summary
- Adds an Inno Setup installer definition.
- Extends the release workflow to build and upload a Windows installer artifact.
- Keeps generated installer outputs ignored.

## Validation
- Checked release workflow syntax and command paths by inspection.
- Verified installer output filename matches the release upload path.
- Verified release version handling strips the leading `v`.

This does not add or claim code signing.