### PR TITLE
Add privacy policy

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,31 @@
+# Privacy Policy
+
+SQMeter Alpaca SafetyMonitor is a local bridge between an SQMeter ESP32 device and ASCOM Alpaca clients on your network.
+
+## Data Collection
+
+The application does not collect analytics, telemetry, personal data, or usage data.
+
+It reads sensor values from the SQMeter device URL that you configure and exposes derived SafetyMonitor status through the local Alpaca HTTP API and web interface.
+
+## Network Communication
+
+The application communicates with:
+
+- The configured SQMeter device on your local network.
+- ASCOM Alpaca clients that connect to the HTTP API.
+- Local network clients using Alpaca discovery, when discovery is enabled.
+
+The application does not send data to a project-operated server.
+
+## Local Files
+
+The application may store local configuration and a generated device UUID file. These files remain on the machine where the application runs unless you copy or back them up yourself.
+
+## Updates
+
+The application does not automatically upload data when checking for or installing updates. Release artifacts are distributed through the project repository.
+
+## Contact
+
+Use the project issue tracker for privacy questions or concerns.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A standalone **ASCOM Alpaca SafetyMonitor** bridge for the [SQMeter ESP32](https
 
 Runs as a single `.exe` on your N.I.N.A. Windows machine.  No ASCOM COM drivers, no registration, no Visual Studio templates — pure Alpaca over HTTP/UDP.
 
+[Privacy policy](PRIVACY.md)
+
 ---
 
 ## What it does


### PR DESCRIPTION
## Summary
- Adds a privacy policy describing the local-only behaviour of the bridge.
- Clarifies that the application does not collect analytics or personal data.
- Links the privacy policy from the README.

## Validation
- Read through docs for clarity.
- Confirmed there are no signing claims.