### PR TITLE
ci: upgrade Codecov action to v5 with token support

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,48 @@
+# GitHub repository settings
+# This can be applied via the Probot Settings app: https://probot.github.io/apps/settings/
+# Or manually configure in Settings → Branches and Settings → General
+
+repository:
+  # Automatically delete head branches after PRs are merged
+  delete_branch_on_merge: true
+  
+  # Allow squash merge
+  allow_squash_merge: true
+  
+  # Allow merge commits
+  allow_merge_commit: true
+  
+  # Allow rebase merge
+  allow_rebase_merge: true
+  
+  # Allow auto-merge
+  allow_auto_merge: true
+
+branches:
+  - name: main
+    protection:
+      # Require pull request before merging
+      required_pull_request_reviews:
+        required_approving_review_count: 0
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: false
+      
+      # Require status checks to pass before merging
+      required_status_checks:
+        strict: true
+        checks:
+          - context: "Lint and Test"
+          - context: "Build"
+          - context: "ASCOM Conformance"
+      
+      # Enforce restrictions for administrators
+      enforce_admins: false
+      
+      # Require branches to be up to date before merging
+      required_linear_history: false
+      
+      # Allow force pushes
+      allow_force_pushes: false
+      
+      # Allow deletions
+      allow_deletions: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,20 +48,21 @@ jobs:
           # Exclude cmd/ — it is process-lifecycle wiring tested via integration,
           # not unit tests. Coverage is measured over internal/ packages only.
           go test $(go list ./... | grep -v '/cmd/') \
-            -coverprofile=coverage.out -covermode=atomic
-          go tool cover -func=coverage.out | tail -1
+            -coverprofile=coverage.txt -covermode=atomic
+          go tool cover -func=coverage.txt | tail -1
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
         with:
-          files: coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.txt
           fail_ci_if_error: false
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:
           name: coverage
-          path: coverage.out
+          path: coverage.txt
 
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,13 +130,13 @@ jobs:
           chmod +x .conform/conformu
 
       - name: Run conformance test
-        run: CONFORM_BIN=.conform/conformu bash scripts/conform.sh
-
+        run: |
+          CONFORM_BIN=.conform/conformu bash scripts/conform.sh 2>&1 | tee conformance.log
+          
       - name: Upload conformance report
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: conformance-report
-          path: |
-            ConformU/
-            *.log
+          path: conformance.log
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 
 # Coverage
 coverage.out
+coverage.txt
 coverage.html
 
 # Config / secrets

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # sqmeter-alpaca-safetymonitor
 
 [![CI](https://github.com/DeanJ87/SQMeter-Safety-Monitor/actions/workflows/ci.yml/badge.svg)](https://github.com/DeanJ87/SQMeter-Safety-Monitor/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/DeanJ87/SQMeter-Safety-Monitor/branch/main/graph/badge.svg)](https://codecov.io/gh/DeanJ87/SQMeter-Safety-Monitor)
+[![codecov](https://codecov.io/github/DeanJ87/SQMeter-Safety-Monitor/graph/badge.svg?token=I7DHSX92BN)](https://codecov.io/github/DeanJ87/SQMeter-Safety-Monitor)
 
 A standalone **ASCOM Alpaca SafetyMonitor** bridge for the [SQMeter ESP32](https://deanj87.github.io/SQMeter/) sky-quality sensor.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,35 @@
+# Codecov configuration
+# https://docs.codecov.com/docs/codecov-yaml
+
+codecov:
+  require_ci_to_pass: false  # Show Codecov status without waiting for other checks
+
+comment:
+  layout: "diff, flags, files"
+  behavior: default
+  require_changes: true   # Only comment when coverage changes
+  require_base: false
+  require_head: true
+  hide_project_coverage: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: 80%       # Required coverage value
+        threshold: 1%     # Allow 1% leniency in hitting the target
+        base: auto
+        if_ci_failed: error
+    
+    patch:
+      default:
+        target: 80%       # Require 80% coverage on new code
+        threshold: 1%
+        if_ci_failed: error
+
+# Ignore paths (don't include in coverage calculation)
+ignore:
+  - "cmd/**/*"           # Exclude cmd/ from coverage (main.go, process wiring)
+  - "**/*_test.go"       # Exclude test files themselves
+  - "**/mock*.go"        # Exclude mock files
+  - "**/testdata/**"     # Exclude test data

--- a/docs/repo-configuration.md
+++ b/docs/repo-configuration.md
@@ -1,0 +1,45 @@
+# GitHub Repository Configuration
+
+## ✅ Completed
+
+- **Auto-delete branches on PR merge**: Enabled via `gh repo edit --delete-branch-on-merge`
+
+## Branch Protection for `main`
+
+To enable branch protection for the `main` branch, run this command:
+
+```bash
+gh api \
+  --method PUT \
+  /repos/DeanJ87/SQMeter-Safety-Monitor/branches/main/protection \
+  --input - <<'EOF'
+{
+  "required_status_checks": {
+    "strict": true,
+    "checks": [
+      {"context": "Lint and Test"},
+      {"context": "Build"}, 
+      {"context": "ASCOM Conformance"}
+    ]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+EOF
+```
+
+Or configure manually in GitHub:
+1. Go to **Settings** → **Branches**
+2. Add a branch protection rule for `main`
+3. Enable:
+   - ☑️ Require status checks to pass before merging
+     - ☑️ Require branches to be up to date before merging
+     - Select: `Lint and Test`, `Build`, `ASCOM Conformance`
+   - ☑️ Do not allow bypassing the above settings (optional)
+
+## Alternative: Probot Settings App
+
+Install the [Probot Settings app](https://probot.github.io/apps/settings/) on your repository to automatically apply the configuration from `.github/settings.yml`.


### PR DESCRIPTION
- Update codecov/codecov-action from v4 to v5
- Add CODECOV_TOKEN secret for authentication
- Change coverage file from coverage.out to coverage.txt
- Update .gitignore to include coverage.txt