### PR TITLE
Add Windows executable and service smoke coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,50 @@ jobs:
           name: binaries
           path: dist/
 
+  windows-smoke:
+    name: Windows Smoke
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Test on Windows
+        run: go test ./...
+
+      - name: Build Windows executable
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
+          New-Item -ItemType Directory -Force -Path dist | Out-Null
+          $date = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+          $ldflags = "-X main.version=ci -X main.commit=${{ github.sha }} -X main.date=$date"
+          go build -ldflags $ldflags -o dist/sqmeter-alpaca-safetymonitor-windows-amd64.exe ./cmd/sqmeter-alpaca-safetymonitor
+
+      - name: Verify Windows executable
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
+          $exe = ".\dist\sqmeter-alpaca-safetymonitor-windows-amd64.exe"
+
+          $versionOutput = & $exe --version
+          $versionOutput
+          if ($versionOutput -notmatch "ci") {
+            throw "version output did not include the CI version"
+          }
+
+          $configPath = Join-Path $env:RUNNER_TEMP "sqmeter-config.json"
+          & $exe --config $configPath --write-default-config
+          & $exe --config $configPath --check-config
+
   conformance:
     name: ASCOM Conformance
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a `windows-latest` CI smoke job.
- Runs `go test ./...` natively on Windows.
- Builds the Windows executable on Windows and verifies `--version`.
- Writes a temporary default config and verifies it with `--check-config`.

## Validation
- Reviewed `.github/workflows/ci.yml` locally.
- `git diff --check`
- Parsed `.github/workflows/ci.yml` as YAML locally.
- `go test ./...`
- `GOOS=windows GOARCH=amd64 go build ... ./cmd/sqmeter-alpaca-safetymonitor`

## Notes / limitations
- Full Windows service install/start/status/stop/uninstall coverage is not included in this PR because it has not been proven reliable on GitHub-hosted Windows runners. This PR keeps the CI coverage to deterministic executable, version, and config smoke checks.
- GitHub Actions will validate the native Windows smoke job after the PR opens.

Refs #13