### PR TITLE
Allow Alpaca discovery to coexist with local servers

### DIFF
--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"net"
 	"strings"
 )
 
@@ -29,8 +28,7 @@ func New(discoveryPort, httpPort int, logger *slog.Logger) *Responder {
 
 // Run starts the UDP listener and blocks until ctx is cancelled.
 func (r *Responder) Run(ctx context.Context) error {
-	addr := &net.UDPAddr{Port: r.discoveryPort}
-	conn, err := net.ListenUDP("udp4", addr)
+	conn, err := listenUDP(r.discoveryPort)
 	if err != nil {
 		return fmt.Errorf("discovery: listen UDP :%d: %w", r.discoveryPort, err)
 	}

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -3,9 +3,11 @@ package discovery_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net"
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -15,9 +17,7 @@ import (
 func TestDiscovery_RespondsWithAlpacaPort(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
-	// Port 0 lets the OS pick a free port, but Responder doesn't expose that.
-	// Use a fixed high port unlikely to conflict in tests.
-	const discPort = 32277
+	discPort := freeUDPPort(t)
 	const httpPort = 11111
 
 	resp := discovery.New(discPort, httpPort, logger)
@@ -30,7 +30,7 @@ func TestDiscovery_RespondsWithAlpacaPort(t *testing.T) {
 		errCh <- resp.Run(ctx)
 	}()
 
-	reply := waitForDiscoveryReply(t, "127.0.0.1:32277", errCh)
+	reply := waitForDiscoveryReply(t, fmt.Sprintf("127.0.0.1:%d", discPort), errCh)
 
 	if got := reply["AlpacaPort"]; got != httpPort {
 		t.Errorf("AlpacaPort: want %d, got %d", httpPort, got)
@@ -39,7 +39,7 @@ func TestDiscovery_RespondsWithAlpacaPort(t *testing.T) {
 
 func TestDiscovery_IgnoresUnrelatedPackets(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	const discPort = 32278
+	discPort := freeUDPPort(t)
 
 	resp := discovery.New(discPort, 11111, logger)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -49,9 +49,9 @@ func TestDiscovery_IgnoresUnrelatedPackets(t *testing.T) {
 	go func() {
 		errCh <- resp.Run(ctx)
 	}()
-	waitForDiscoveryReply(t, "127.0.0.1:32278", errCh)
+	waitForDiscoveryReply(t, fmt.Sprintf("127.0.0.1:%d", discPort), errCh)
 
-	conn, err := net.Dial("udp4", "127.0.0.1:32278")
+	conn, err := net.Dial("udp4", fmt.Sprintf("127.0.0.1:%d", discPort))
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
@@ -66,6 +66,65 @@ func TestDiscovery_IgnoresUnrelatedPackets(t *testing.T) {
 		t.Error("expected no response to unrelated packet, but got one")
 	}
 	// A deadline/timeout error is expected and correct here.
+}
+
+func TestDiscovery_AllowsSharedBindOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("shared Alpaca discovery bind is Windows-specific")
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	discPort := freeUDPPort(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 2)
+	for _, httpPort := range []int{32323, 11111} {
+		resp := discovery.New(discPort, httpPort, logger)
+		go func() {
+			errCh <- resp.Run(ctx)
+		}()
+	}
+
+	replies := waitForDiscoveryReplies(t, fmt.Sprintf("127.0.0.1:%d", discPort), errCh, 2)
+	for _, want := range []int{32323, 11111} {
+		if !replies[want] {
+			t.Fatalf("missing AlpacaPort %d in replies: %v", want, replies)
+		}
+	}
+}
+
+func TestDiscovery_RejectsSecondBindOnNonWindows(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows permits shared Alpaca discovery binds")
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	discPort := freeUDPPort(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	firstErrCh := make(chan error, 1)
+	go func() {
+		firstErrCh <- discovery.New(discPort, 11111, logger).Run(ctx)
+	}()
+	waitForDiscoveryReply(t, fmt.Sprintf("127.0.0.1:%d", discPort), firstErrCh)
+
+	secondErrCh := make(chan error, 1)
+	go func() {
+		secondErrCh <- discovery.New(discPort, 32323, logger).Run(ctx)
+	}()
+
+	select {
+	case err := <-secondErrCh:
+		if err == nil {
+			t.Fatal("expected second discovery responder to fail binding")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for second discovery responder bind failure")
+	}
 }
 
 func waitForDiscoveryReply(t *testing.T, addr string, errCh <-chan error) map[string]int {
@@ -89,6 +148,18 @@ func waitForDiscoveryReply(t *testing.T, addr string, errCh <-chan error) map[st
 
 	t.Fatalf("timed out waiting for discovery reply: %v", lastErr)
 	return nil
+}
+
+func freeUDPPort(t *testing.T) int {
+	t.Helper()
+
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.ParseIP("127.0.0.1")})
+	if err != nil {
+		t.Fatalf("reserve UDP port: %v", err)
+	}
+	defer conn.Close()
+
+	return conn.LocalAddr().(*net.UDPAddr).Port
 }
 
 func readDiscoveryReply(addr string, timeout time.Duration) (map[string]int, error) {
@@ -116,4 +187,67 @@ func readDiscoveryReply(addr string, timeout time.Duration) (map[string]int, err
 		return nil, err
 	}
 	return reply, nil
+}
+
+func waitForDiscoveryReplies(t *testing.T, addr string, errCh <-chan error, want int) map[int]bool {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	replies := make(map[int]bool)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-errCh:
+			t.Fatalf("discovery responder exited before it was ready: %v", err)
+		default:
+		}
+
+		got, err := readDiscoveryReplies(addr, 100*time.Millisecond)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		for port := range got {
+			replies[port] = true
+		}
+		if len(replies) >= want {
+			return replies
+		}
+	}
+
+	t.Fatalf("timed out waiting for discovery replies: got %v, last error: %v", replies, lastErr)
+	return nil
+}
+
+func readDiscoveryReplies(addr string, timeout time.Duration) (map[int]bool, error) {
+	conn, err := net.Dial("udp4", addr)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
+		return nil, err
+	}
+	if _, err := conn.Write([]byte("alpacadiscovery1")); err != nil {
+		return nil, err
+	}
+
+	replies := make(map[int]bool)
+	buf := make([]byte, 256)
+	for {
+		n, err := conn.Read(buf)
+		if err != nil {
+			if len(replies) > 0 {
+				return replies, nil
+			}
+			return nil, err
+		}
+
+		var reply map[string]int
+		if err := json.Unmarshal(buf[:n], &reply); err != nil {
+			return nil, err
+		}
+		replies[reply["AlpacaPort"]] = true
+	}
 }

--- a/internal/discovery/listen_default.go
+++ b/internal/discovery/listen_default.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package discovery
+
+import "net"
+
+func listenUDP(port int) (*net.UDPConn, error) {
+	return net.ListenUDP("udp4", &net.UDPAddr{Port: port})
+}

--- a/internal/discovery/listen_windows.go
+++ b/internal/discovery/listen_windows.go
@@ -1,0 +1,40 @@
+//go:build windows
+
+package discovery
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+func listenUDP(port int) (*net.UDPConn, error) {
+	lc := net.ListenConfig{
+		Control: func(network, address string, conn syscall.RawConn) error {
+			var sockOptErr error
+			if err := conn.Control(func(fd uintptr) {
+				// Alpaca discovery is a shared UDP port; this lets compatible
+				// Windows responders bind alongside each other.
+				sockOptErr = windows.SetsockoptInt(windows.Handle(fd), windows.SOL_SOCKET, windows.SO_REUSEADDR, 1)
+			}); err != nil {
+				return err
+			}
+			return sockOptErr
+		},
+	}
+
+	packetConn, err := lc.ListenPacket(context.Background(), "udp4", fmt.Sprintf(":%d", port))
+	if err != nil {
+		return nil, err
+	}
+
+	udpConn, ok := packetConn.(*net.UDPConn)
+	if !ok {
+		packetConn.Close()
+		return nil, fmt.Errorf("unexpected UDP listener type %T", packetConn)
+	}
+	return udpConn, nil
+}


### PR DESCRIPTION
## Summary

- Adds a platform-specific discovery listener helper.
- Uses Windows socket reuse so SQMeter SafetyMonitor can share the Alpaca UDP discovery port with other local Alpaca servers where supported.
- Preserves existing `net.ListenUDP` behaviour on non-Windows platforms.
- Adds tests for Windows shared-bind behaviour and non-Windows bind conflict behaviour.

## Validation

- `go test ./internal/discovery`
- `go test ./...`

## Notes

Windows manual validation is still required with ASCOM Alpaca Simulators running:

1. Start ASCOM Alpaca Simulators.
2. Start SQMeter SafetyMonitor on `127.0.0.1:11111`.
3. Broadcast `alpacadiscovery1` to UDP `32227`.
4. Confirm responses include both:
   - `{"AlpacaPort": 32323}`
   - `{"AlpacaPort": 11111}`
5. Confirm N.I.N.A. can discover `SQMeter SafetyMonitor`.

Closes #16