### PR TITLE
Clarify restart-required config changes in setup and API responses

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -165,11 +165,25 @@ func validate(cfg *Config) error {
 	return nil
 }
 
+// RestartRequiredFields returns the config fields whose new values require a
+// server restart before they take effect.
+func RestartRequiredFields(old, new_ *Config) []string {
+	fields := make([]string, 0, 3)
+	if old.AlpacaHTTPBind != new_.AlpacaHTTPBind {
+		fields = append(fields, "ALPACA_HTTP_BIND")
+	}
+	if old.AlpacaHTTPPort != new_.AlpacaHTTPPort {
+		fields = append(fields, "ALPACA_HTTP_PORT")
+	}
+	if old.AlpacaDiscoveryPort != new_.AlpacaDiscoveryPort {
+		fields = append(fields, "ALPACA_DISCOVERY_PORT")
+	}
+	return fields
+}
+
 // NeedsRestart returns true if changing from old to new requires a server restart.
 func NeedsRestart(old, new_ *Config) bool {
-	return old.AlpacaHTTPBind != new_.AlpacaHTTPBind ||
-		old.AlpacaHTTPPort != new_.AlpacaHTTPPort ||
-		old.AlpacaDiscoveryPort != new_.AlpacaDiscoveryPort
+	return len(RestartRequiredFields(old, new_)) > 0
 }
 
 // IsWideOpen returns true when the bind address is not loopback-only, meaning

--- a/internal/config/config_extra_test.go
+++ b/internal/config/config_extra_test.go
@@ -3,6 +3,7 @@ package config_test
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -52,6 +53,32 @@ func TestNeedsRestart_BindChange(t *testing.T) {
 	b.AlpacaHTTPBind = "0.0.0.0"
 	if !config.NeedsRestart(a, &b) {
 		t.Error("bind address change should require restart")
+	}
+}
+
+func TestRestartRequiredFields_NamesChangedRestartFields(t *testing.T) {
+	a := config.Defaults()
+	b := *a
+	b.AlpacaHTTPBind = "0.0.0.0"
+	b.AlpacaHTTPPort = 22222
+	b.AlpacaDiscoveryPort = 33333
+
+	got := config.RestartRequiredFields(a, &b)
+	want := []string{"ALPACA_HTTP_BIND", "ALPACA_HTTP_PORT", "ALPACA_DISCOVERY_PORT"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("RestartRequiredFields() = %#v, want %#v", got, want)
+	}
+}
+
+func TestRestartRequiredFields_IgnoresHotReloadableFields(t *testing.T) {
+	a := config.Defaults()
+	b := *a
+	b.SQMeterBaseURL = "http://other.local"
+	b.LogLevel = "debug"
+
+	got := config.RestartRequiredFields(a, &b)
+	if len(got) != 0 {
+		t.Fatalf("RestartRequiredFields() = %#v, want empty", got)
 	}
 }
 

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -135,12 +135,13 @@ func (h *Handler) StatusJSON(w http.ResponseWriter, r *http.Request) {
 // ---------- setup page -------------------------------------------------------
 
 type SetupData struct {
-	Config       *config.Config
-	ConfigPath   string
-	WideOpen     bool
-	SavedOK      bool
-	NeedsRestart bool
-	ErrorMsg     string
+	Config                *config.Config
+	ConfigPath            string
+	WideOpen              bool
+	SavedOK               bool
+	NeedsRestart          bool
+	RestartRequiredFields []string
+	ErrorMsg              string
 	// Pre-formatted optional fields (empty string = disabled)
 	SQMMinSafe         string
 	HumidityMaxSafe    string
@@ -149,13 +150,15 @@ type SetupData struct {
 
 func newSetupData(cfgHolder *config.Holder, q url.Values) SetupData {
 	cfg := cfgHolder.Get()
+	restartFields := q["restart_required_fields"]
 	d := SetupData{
-		Config:       cfg,
-		ConfigPath:   cfgHolder.Path(),
-		WideOpen:     config.IsWideOpen(cfg.AlpacaHTTPBind),
-		SavedOK:      q.Get("saved") == "1",
-		NeedsRestart: q.Get("restart") == "1",
-		ErrorMsg:     q.Get("error"),
+		Config:                cfg,
+		ConfigPath:            cfgHolder.Path(),
+		WideOpen:              config.IsWideOpen(cfg.AlpacaHTTPBind),
+		SavedOK:               q.Get("saved") == "1",
+		NeedsRestart:          q.Get("restart") == "1" || len(restartFields) > 0,
+		RestartRequiredFields: restartFields,
+		ErrorMsg:              q.Get("error"),
 	}
 	if cfg.SQMMinSafe != nil {
 		d.SQMMinSafe = fmt.Sprintf("%.2f", *cfg.SQMMinSafe)
@@ -210,11 +213,14 @@ func (h *Handler) PostSetup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	q := "/setup?saved=1"
-	if config.NeedsRestart(old, &updated) {
-		q += "&restart=1"
+	q := url.Values{"saved": {"1"}}
+	for _, field := range config.RestartRequiredFields(old, &updated) {
+		q.Add("restart_required_fields", field)
 	}
-	http.Redirect(w, r, q, http.StatusSeeOther)
+	if len(q["restart_required_fields"]) > 0 {
+		q.Set("restart", "1")
+	}
+	http.Redirect(w, r, "/setup?"+q.Encode(), http.StatusSeeOther)
 }
 
 // ---------- config JSON API --------------------------------------------------
@@ -241,7 +247,7 @@ func (h *Handler) PutConfigJSON(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	restartNeeded := config.NeedsRestart(old, &updated)
+	restartFields := config.RestartRequiredFields(old, &updated)
 	if err := h.cfgHolder.Update(&updated); err != nil {
 		http.Error(w, `{"error":"`+err.Error()+`"}`, http.StatusUnprocessableEntity)
 		return
@@ -249,12 +255,19 @@ func (h *Handler) PutConfigJSON(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	type result struct {
-		Config       *config.Config `json:"config"`
-		NeedsRestart bool           `json:"needsRestart"`
+		Config                *config.Config `json:"config"`
+		RestartRequired       bool           `json:"restart_required"`
+		RestartRequiredFields []string       `json:"restart_required_fields"`
+		NeedsRestart          bool           `json:"needsRestart"`
 	}
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
-	_ = enc.Encode(result{Config: h.cfgHolder.Get(), NeedsRestart: restartNeeded})
+	_ = enc.Encode(result{
+		Config:                h.cfgHolder.Get(),
+		RestartRequired:       len(restartFields) > 0,
+		RestartRequiredFields: restartFields,
+		NeedsRestart:          len(restartFields) > 0,
+	})
 }
 
 // ---------- form helpers -----------------------------------------------------

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -221,6 +221,53 @@ func TestPostSetup_UpdatesConfig(t *testing.T) {
 	}
 }
 
+func TestPostSetup_RestartRequiredFieldsInRedirect(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	form := url.Values{}
+	form.Set("SQMETER_BASE_URL", "http://sqmeter.local")
+	form.Set("ALPACA_HTTP_BIND", "0.0.0.0")
+	form.Set("ALPACA_HTTP_PORT", "22222")
+	form.Set("ALPACA_DISCOVERY_PORT", "32227")
+	form.Set("POLL_INTERVAL_SECONDS", "5")
+	form.Set("STALE_AFTER_SECONDS", "30")
+	form.Set("FAIL_CLOSED", "true")
+	form.Set("CONNECTED_ON_STARTUP", "true")
+	form.Set("CLOUD_COVER_UNSAFE_PERCENT", "80")
+	form.Set("CLOUD_COVER_CAUTION_PERCENT", "50")
+	form.Set("MANUAL_OVERRIDE", "auto")
+	form.Set("LOG_LEVEL", "info")
+
+	w := serve(t, h, http.MethodPost, "/setup", form.Encode())
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("POST /setup: want 303 redirect, got %d", w.Code)
+	}
+
+	loc := w.Header().Get("Location")
+	if !strings.Contains(loc, "restart=1") {
+		t.Fatalf("POST /setup redirect: expected restart flag, got %q", loc)
+	}
+	if !strings.Contains(loc, "restart_required_fields=ALPACA_HTTP_BIND") {
+		t.Fatalf("POST /setup redirect: expected ALPACA_HTTP_BIND field, got %q", loc)
+	}
+	if !strings.Contains(loc, "restart_required_fields=ALPACA_HTTP_PORT") {
+		t.Fatalf("POST /setup redirect: expected ALPACA_HTTP_PORT field, got %q", loc)
+	}
+}
+
+func TestGetSetup_RestartWarningListsFields(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	path := "/setup?saved=1&restart_required_fields=ALPACA_HTTP_BIND&restart_required_fields=ALPACA_HTTP_PORT"
+
+	w := serve(t, h, http.MethodGet, path, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /setup: want 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "ALPACA_HTTP_BIND") || !strings.Contains(body, "ALPACA_HTTP_PORT") {
+		t.Fatalf("GET /setup warning did not list restart-required fields: %s", body)
+	}
+}
+
 // ---------- /config.json API -------------------------------------------------
 
 func TestGetConfigJSON_ValidJSON(t *testing.T) {
@@ -275,10 +322,42 @@ func TestPutConfigJSON_NeedsRestart_FlaggedInResponse(t *testing.T) {
 	w := serve(t, h, http.MethodPut, "/config.json", body)
 
 	var resp struct {
-		NeedsRestart bool `json:"needsRestart"`
+		RestartRequired       bool     `json:"restart_required"`
+		RestartRequiredFields []string `json:"restart_required_fields"`
+		NeedsRestart          bool     `json:"needsRestart"`
 	}
 	json.NewDecoder(w.Body).Decode(&resp)
+	if !resp.RestartRequired {
+		t.Error("expected restart_required=true when HTTP port changes")
+	}
 	if !resp.NeedsRestart {
-		t.Error("expected needsRestart=true when HTTP port changes")
+		t.Error("expected legacy needsRestart=true when HTTP port changes")
+	}
+	if len(resp.RestartRequiredFields) != 1 || resp.RestartRequiredFields[0] != "ALPACA_HTTP_PORT" {
+		t.Fatalf("restart_required_fields = %#v, want [ALPACA_HTTP_PORT]", resp.RestartRequiredFields)
+	}
+}
+
+func TestPutConfigJSON_NoRestart_ReportsFalseAndEmptyFields(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	body := `{"SQMETER_BASE_URL":"http://put-updated.local"}`
+	w := serve(t, h, http.MethodPut, "/config.json", body)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PUT /config.json: want 200, got %d - body: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		RestartRequired       bool     `json:"restart_required"`
+		RestartRequiredFields []string `json:"restart_required_fields"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("PUT /config.json: invalid JSON: %v", err)
+	}
+	if resp.RestartRequired {
+		t.Error("expected restart_required=false for hot-reloadable field")
+	}
+	if len(resp.RestartRequiredFields) != 0 {
+		t.Fatalf("restart_required_fields = %#v, want empty", resp.RestartRequiredFields)
 	}
 }

--- a/internal/web/templates/setup.html
+++ b/internal/web/templates/setup.html
@@ -47,6 +47,13 @@
     color: var(--warn-fg); border-radius: 6px;
     padding: 10px 16px; margin-bottom: 16px;
   }
+  .flash-restart ul {
+    margin: 6px 0 0 18px;
+  }
+  .flash-restart code {
+    font-family: 'Courier New', monospace;
+    color: var(--text);
+  }
   .flash-err {
     background: #3d0a0a; border: 1px solid var(--unsafe-fg);
     color: var(--unsafe-fg); border-radius: 6px;
@@ -150,7 +157,16 @@
 <div class="flash-ok">✓ Configuration saved successfully.</div>
 {{end}}
 {{if .NeedsRestart}}
-<div class="flash-restart">⚠ Some changes (HTTP bind/port, discovery port) require a restart to take effect.</div>
+<div class="flash-restart">
+  ⚠ Saved changes include settings that require a service restart before they take effect.
+  {{if .RestartRequiredFields}}
+  <ul>
+    {{range .RestartRequiredFields}}<li><code>{{.}}</code></li>{{end}}
+  </ul>
+  {{else}}
+  <div>Restart-required fields: <code>ALPACA_HTTP_BIND</code>, <code>ALPACA_HTTP_PORT</code>, <code>ALPACA_DISCOVERY_PORT</code>.</div>
+  {{end}}
+</div>
 {{end}}
 {{if .ErrorMsg}}
 <div class="flash-err">✗ Error: {{.ErrorMsg}}</div>


### PR DESCRIPTION
## Summary

- Improves restart-required config feedback in the setup/API flow.
- Keeps the current behaviour of saving restart-required fields.
- Does not reject restart-required changes.
- Does not attempt live listener rebinding.

## Validation

- `go test ./internal/config ./internal/web`
- `go test ./...`

Closes #12
