### PR TITLE
Report Alpaca discovery bind failures and listener health

### DIFF
--- a/cmd/sqmeter-alpaca-safetymonitor/main.go
+++ b/cmd/sqmeter-alpaca-safetymonitor/main.go
@@ -116,6 +116,9 @@ func (p *program) run(ctx context.Context, interactive bool) {
 
 	alpacaHandler := alpaca.New(cfgHolder, stateHolder, deviceUUID, version, pol.PollNow)
 
+	disc := discovery.New(cfg.AlpacaDiscoveryPort, cfg.AlpacaHTTPPort, logger)
+	webHandler.WithDiscovery(disc.GetStatus)
+
 	mux := http.NewServeMux()
 	alpacaHandler.Register(mux)
 	webHandler.Register(mux)
@@ -133,8 +136,6 @@ func (p *program) run(ctx context.Context, interactive bool) {
 		logger.Error("failed to bind HTTP port", "addr", listenAddr, "error", err)
 		return
 	}
-
-	disc := discovery.New(cfg.AlpacaDiscoveryPort, cfg.AlpacaHTTPPort, logger)
 
 	var wg sync.WaitGroup
 

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -7,15 +7,31 @@ import (
 	"log/slog"
 	"net"
 	"strings"
+	"sync"
+	"time"
 )
 
 const discoveryMessage = "alpacadiscovery1"
+
+// Status describes the current health of the discovery listener.
+type Status struct {
+	ConfiguredPort int        `json:"configured_port"`
+	Running        bool       `json:"running"`
+	Healthy        bool       `json:"healthy"`
+	LastError      string     `json:"last_error,omitempty"`
+	LastRequestAt  *time.Time `json:"last_request_at"`
+	LastResponseAt *time.Time `json:"last_response_at"`
+	ResponseCount  int64      `json:"response_count"`
+}
 
 // Responder listens on UDP and answers ASCOM Alpaca discovery broadcasts.
 type Responder struct {
 	discoveryPort int
 	httpPort      int
 	logger        *slog.Logger
+
+	mu     sync.RWMutex
+	status Status
 }
 
 // New creates a Responder that will advertise httpPort on discoveryPort.
@@ -24,7 +40,15 @@ func New(discoveryPort, httpPort int, logger *slog.Logger) *Responder {
 		discoveryPort: discoveryPort,
 		httpPort:      httpPort,
 		logger:        logger,
+		status:        Status{ConfiguredPort: discoveryPort},
 	}
+}
+
+// GetStatus returns a snapshot of the current discovery listener health.
+func (r *Responder) GetStatus() Status {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.status
 }
 
 // Run starts the UDP listener and blocks until ctx is cancelled.
@@ -32,9 +56,21 @@ func (r *Responder) Run(ctx context.Context) error {
 	addr := &net.UDPAddr{Port: r.discoveryPort}
 	conn, err := net.ListenUDP("udp4", addr)
 	if err != nil {
-		return fmt.Errorf("discovery: listen UDP :%d: %w", r.discoveryPort, err)
+		bindErr := fmt.Errorf("discovery: listen UDP :%d: %w", r.discoveryPort, err)
+		r.mu.Lock()
+		r.status.Running = false
+		r.status.Healthy = false
+		r.status.LastError = bindErr.Error()
+		r.mu.Unlock()
+		return bindErr
 	}
 	defer conn.Close()
+
+	r.mu.Lock()
+	r.status.Running = true
+	r.status.Healthy = true
+	r.status.LastError = ""
+	r.mu.Unlock()
 
 	r.logger.Info("alpaca discovery listening", "udp_port", r.discoveryPort)
 
@@ -51,6 +87,9 @@ func (r *Responder) Run(ctx context.Context) error {
 		if err != nil {
 			select {
 			case <-ctx.Done():
+				r.mu.Lock()
+				r.status.Running = false
+				r.mu.Unlock()
 				return nil
 			default:
 				r.logger.Warn("discovery: read error", "error", err)
@@ -60,9 +99,20 @@ func (r *Responder) Run(ctx context.Context) error {
 
 		msg := strings.TrimSpace(string(buf[:n]))
 		if msg == discoveryMessage {
+			now := time.Now().UTC()
+			r.mu.Lock()
+			r.status.LastRequestAt = &now
+			r.mu.Unlock()
+
 			r.logger.Debug("discovery: received probe", "from", remote)
 			if _, werr := conn.WriteToUDP(reply, remote); werr != nil {
 				r.logger.Warn("discovery: write error", "error", werr)
+			} else {
+				sent := time.Now().UTC()
+				r.mu.Lock()
+				r.status.LastResponseAt = &sent
+				r.status.ResponseCount++
+				r.mu.Unlock()
 			}
 		}
 	}

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -107,13 +107,12 @@ func (r *Responder) Run(ctx context.Context) error {
 			r.logger.Debug("discovery: received probe", "from", remote)
 			if _, werr := conn.WriteToUDP(reply, remote); werr != nil {
 				r.logger.Warn("discovery: write error", "error", werr)
-			} else {
-				sent := time.Now().UTC()
-				r.mu.Lock()
-				r.status.LastResponseAt = &sent
-				r.status.ResponseCount++
-				r.mu.Unlock()
 			}
+			sent := time.Now().UTC()
+			r.mu.Lock()
+			r.status.LastResponseAt = &sent
+			r.status.ResponseCount++
+			r.mu.Unlock()
 		}
 	}
 }

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -37,6 +37,112 @@ func TestDiscovery_RespondsWithAlpacaPort(t *testing.T) {
 	}
 }
 
+func TestDiscovery_GetStatus_HealthyAfterBind(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	const discPort = 32279
+
+	resp := discovery.New(discPort, 11111, logger)
+
+	// Before Run: not running, not healthy.
+	s := resp.GetStatus()
+	if s.Running || s.Healthy {
+		t.Errorf("before Run: want running=false healthy=false, got running=%v healthy=%v", s.Running, s.Healthy)
+	}
+	if s.ConfiguredPort != discPort {
+		t.Errorf("ConfiguredPort: want %d, got %d", discPort, s.ConfiguredPort)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- resp.Run(ctx) }()
+
+	// Wait until listener is up by sending a probe.
+	waitForDiscoveryReply(t, "127.0.0.1:32279", errCh)
+
+	s = resp.GetStatus()
+	if !s.Running {
+		t.Error("after bind: want running=true")
+	}
+	if !s.Healthy {
+		t.Error("after bind: want healthy=true")
+	}
+	if s.LastError != "" {
+		t.Errorf("after bind: want no error, got %q", s.LastError)
+	}
+	if s.ResponseCount < 1 {
+		t.Errorf("after probe: want ResponseCount >= 1, got %d", s.ResponseCount)
+	}
+	if s.LastRequestAt == nil {
+		t.Error("after probe: want LastRequestAt set")
+	}
+	if s.LastResponseAt == nil {
+		t.Error("after probe: want LastResponseAt set")
+	}
+}
+
+func TestDiscovery_GetStatus_UnhealthyOnBindFailure(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	const discPort = 32280
+
+	// Occupy the port so the responder cannot bind.
+	occupier, err := net.ListenUDP("udp4", &net.UDPAddr{Port: discPort})
+	if err != nil {
+		t.Fatalf("could not occupy port %d for test: %v", discPort, err)
+	}
+	defer occupier.Close()
+
+	resp := discovery.New(discPort, 11111, logger)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	runErr := resp.Run(ctx)
+	if runErr == nil {
+		t.Fatal("expected Run to return an error when port is occupied")
+	}
+
+	s := resp.GetStatus()
+	if s.Running {
+		t.Error("after bind failure: want running=false")
+	}
+	if s.Healthy {
+		t.Error("after bind failure: want healthy=false")
+	}
+	if s.LastError == "" {
+		t.Error("after bind failure: want LastError set")
+	}
+}
+
+func TestDiscovery_GetStatus_RunningFalseAfterStop(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	const discPort = 32281
+
+	resp := discovery.New(discPort, 11111, logger)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- resp.Run(ctx) }()
+
+	waitForDiscoveryReply(t, "127.0.0.1:32281", errCh)
+
+	cancel()
+	select {
+	case <-errCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after context cancel")
+	}
+
+	s := resp.GetStatus()
+	if s.Running {
+		t.Error("after stop: want running=false")
+	}
+	// Healthy stays true — the listener was healthy, just stopped cleanly.
+	if !s.Healthy {
+		t.Error("after clean stop: want healthy=true (was healthy, stopped cleanly)")
+	}
+}
+
 func TestDiscovery_IgnoresUnrelatedPackets(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	const discPort = 32278

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -12,16 +12,24 @@ import (
 
 	"sqmeter-alpaca-safetymonitor/internal/alpaca"
 	"sqmeter-alpaca-safetymonitor/internal/config"
+	"sqmeter-alpaca-safetymonitor/internal/discovery"
 	"sqmeter-alpaca-safetymonitor/internal/state"
 )
 
 // Handler serves the local web dashboard, setup page, and utility endpoints.
 type Handler struct {
-	cfgHolder *config.Holder
-	holder    *state.Holder
-	dash      *template.Template
-	setup     *template.Template
-	startT    time.Time
+	cfgHolder       *config.Holder
+	holder          *state.Holder
+	dash            *template.Template
+	setup           *template.Template
+	startT          time.Time
+	discoveryStatus func() discovery.Status
+}
+
+// WithDiscovery registers a discovery status getter so the handler can expose
+// listener health via the dashboard and /status.json.
+func (h *Handler) WithDiscovery(fn func() discovery.Status) {
+	h.discoveryStatus = fn
 }
 
 // New creates a Handler with embedded templates.
@@ -58,18 +66,22 @@ func (h *Handler) Register(mux *http.ServeMux) {
 // ---------- dashboard --------------------------------------------------------
 
 type DashboardData struct {
-	SQMeterURL    string
-	HTTPPort      int
-	DiscoveryPort int
-	Uptime        string
-	State         state.EvaluatedState
-	Connected     bool
-	Override      string
-	LastPoll      string
-	LastSuccess   string
-	HasData       bool
-	DewMargin     float64
-	WideOpen      bool
+	SQMeterURL        string
+	HTTPPort          int
+	DiscoveryPort     int
+	Uptime            string
+	State             state.EvaluatedState
+	Connected         bool
+	Override          string
+	LastPoll          string
+	LastSuccess       string
+	HasData           bool
+	DewMargin         float64
+	WideOpen          bool
+	DiscoveryRunning  bool
+	DiscoveryHealthy  bool
+	DiscoveryError    string
+	DiscoveryHasStats bool // true when we have a status getter
 }
 
 func (h *Handler) Dashboard(w http.ResponseWriter, r *http.Request) {
@@ -99,6 +111,13 @@ func (h *Handler) Dashboard(w http.ResponseWriter, r *http.Request) {
 		DewMargin:     s.Values.Temperature - s.Values.Dewpoint,
 		WideOpen:      config.IsWideOpen(cfg.AlpacaHTTPBind),
 	}
+	if h.discoveryStatus != nil {
+		ds := h.discoveryStatus()
+		data.DiscoveryHasStats = true
+		data.DiscoveryRunning = ds.Running
+		data.DiscoveryHealthy = ds.Healthy
+		data.DiscoveryError = ds.LastError
+	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := h.dash.Execute(w, data); err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
@@ -126,10 +145,21 @@ func (h *Handler) StatusJSON(w http.ResponseWriter, r *http.Request) {
 	s := h.holder.Get()
 	cfg := h.cfgHolder.Get()
 	j := alpaca.BuildStatusJSON(s, h.holder.IsConnected(), cfg.ManualOverride)
+
+	type fullStatus struct {
+		alpaca.StatusJSON
+		Discovery *discovery.Status `json:"discovery,omitempty"`
+	}
+	full := fullStatus{StatusJSON: j}
+	if h.discoveryStatus != nil {
+		ds := h.discoveryStatus()
+		full.Discovery = &ds
+	}
+
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
-	_ = enc.Encode(j)
+	_ = enc.Encode(full)
 }
 
 // ---------- setup page -------------------------------------------------------

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -150,6 +150,36 @@ func TestDashboard_Renders200(t *testing.T) {
 	}
 }
 
+func TestDashboard_WithDiscoveryStatus_Healthy(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	h.WithDiscovery(func() discovery.Status {
+		return discovery.Status{ConfiguredPort: 32227, Running: true, Healthy: true}
+	})
+	w := serve(t, h, http.MethodGet, "/", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("dashboard with discovery: want 200, got %d", w.Code)
+	}
+}
+
+func TestDashboard_WithDiscoveryStatus_Unhealthy(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	h.WithDiscovery(func() discovery.Status {
+		return discovery.Status{
+			ConfiguredPort: 32227,
+			Running:        false,
+			Healthy:        false,
+			LastError:      "listen udp :32227: bind: address already in use",
+		}
+	})
+	w := serve(t, h, http.MethodGet, "/", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("dashboard unhealthy discovery: want 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "not running") {
+		t.Error("dashboard: expected 'not running' text for unhealthy discovery")
+	}
+}
+
 func TestDashboard_AliasedFromStatus(t *testing.T) {
 	h, _, _ := newTestWebHandler(t, true, safeEv())
 	w := serve(t, h, http.MethodGet, "/status", "")

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"sqmeter-alpaca-safetymonitor/internal/config"
+	"sqmeter-alpaca-safetymonitor/internal/discovery"
 	"sqmeter-alpaca-safetymonitor/internal/state"
 	"sqmeter-alpaca-safetymonitor/internal/web"
 )
@@ -280,5 +281,86 @@ func TestPutConfigJSON_NeedsRestart_FlaggedInResponse(t *testing.T) {
 	json.NewDecoder(w.Body).Decode(&resp)
 	if !resp.NeedsRestart {
 		t.Error("expected needsRestart=true when HTTP port changes")
+	}
+}
+
+// ---------- /status.json discovery field ------------------------------------
+
+func TestStatusJSON_DiscoveryField_WhenHealthy(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	h.WithDiscovery(func() discovery.Status {
+		return discovery.Status{
+			ConfiguredPort: 32227,
+			Running:        true,
+			Healthy:        true,
+			ResponseCount:  3,
+		}
+	})
+
+	w := serve(t, h, http.MethodGet, "/status.json", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status.json: want 200, got %d", w.Code)
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("status.json: invalid JSON: %v", err)
+	}
+
+	disc, ok := body["discovery"].(map[string]any)
+	if !ok {
+		t.Fatalf("status.json: expected discovery field, got %T", body["discovery"])
+	}
+	if disc["running"] != true {
+		t.Errorf("discovery.running: want true, got %v", disc["running"])
+	}
+	if disc["healthy"] != true {
+		t.Errorf("discovery.healthy: want true, got %v", disc["healthy"])
+	}
+	if port, _ := disc["configured_port"].(float64); int(port) != 32227 {
+		t.Errorf("discovery.configured_port: want 32227, got %v", disc["configured_port"])
+	}
+}
+
+func TestStatusJSON_DiscoveryField_WhenUnhealthy(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	h.WithDiscovery(func() discovery.Status {
+		return discovery.Status{
+			ConfiguredPort: 32227,
+			Running:        false,
+			Healthy:        false,
+			LastError:      "listen udp :32227: bind: address already in use",
+		}
+	})
+
+	w := serve(t, h, http.MethodGet, "/status.json", "")
+	var body map[string]any
+	json.NewDecoder(w.Body).Decode(&body)
+
+	disc, ok := body["discovery"].(map[string]any)
+	if !ok {
+		t.Fatalf("status.json: expected discovery field")
+	}
+	if disc["running"] != false {
+		t.Errorf("discovery.running: want false, got %v", disc["running"])
+	}
+	if disc["healthy"] != false {
+		t.Errorf("discovery.healthy: want false, got %v", disc["healthy"])
+	}
+	if disc["last_error"] == "" || disc["last_error"] == nil {
+		t.Error("discovery.last_error: expected non-empty error string")
+	}
+}
+
+func TestStatusJSON_NoDiscoveryField_WhenNotWired(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	// no WithDiscovery call
+
+	w := serve(t, h, http.MethodGet, "/status.json", "")
+	var body map[string]any
+	json.NewDecoder(w.Body).Decode(&body)
+
+	if _, present := body["discovery"]; present {
+		t.Error("status.json: discovery field should be absent when no getter is wired")
 	}
 }

--- a/internal/web/templates/dashboard.html
+++ b/internal/web/templates/dashboard.html
@@ -137,7 +137,7 @@
   </div>
   <div style="text-align:right">
     <small>SQMeter: <code>{{.SQMeterURL}}</code></small><br>
-    <small>Discovery UDP: {{.DiscoveryPort}}</small>
+    <small>Discovery UDP: {{.DiscoveryPort}}{{if .DiscoveryHasStats}}{{if .DiscoveryRunning}} <span style="color:#2ecc71">&#x25cf; running</span>{{else}} <span style="color:#e74c3c">&#x25cf; not running</span>{{end}}{{end}}</small>
   </div>
 </header>
 
@@ -155,6 +155,12 @@
 {{if eq .Override "force_unsafe"}}
 <div class="override-warn">⛔ MANUAL OVERRIDE: force_unsafe — always reporting UNSAFE
   <a href="/setup" style="color:var(--warn-fg);margin-left:8px;font-weight:normal;">[Setup]</a>
+</div>
+{{end}}
+{{if and .DiscoveryHasStats (not .DiscoveryHealthy)}}
+<div class="override-warn" style="background:#3d0a0a;border-color:#e74c3c;color:#e74c3c;">
+  ✗ Alpaca UDP discovery is not running — N.I.N.A. auto-discovery will not work.{{if .DiscoveryError}} Error: {{.DiscoveryError}}{{end}}
+  <a href="/setup" style="color:#e74c3c;margin-left:8px;font-weight:normal;">[Setup]</a>
 </div>
 {{end}}
 
@@ -243,9 +249,17 @@
       <span class="v {{if ne .Override "auto"}}warn{{end}}">{{.Override}}</span></div>
     <div class="kv"><span class="k">Has data</span>
       <span class="v {{if .HasData}}ok{{else}}err{{end}}">{{if .HasData}}yes{{else}}no{{end}}</span></div>
+    {{if .DiscoveryHasStats}}
+    <div class="kv"><span class="k">Discovery UDP</span>
+      <span class="v {{if .DiscoveryRunning}}ok{{else}}err{{end}}">{{if .DiscoveryRunning}}running{{else}}not running{{end}}</span></div>
+    {{end}}
     {{if .State.LastError}}
     <div class="kv"><span class="k">Last error</span>
       <span class="v err" style="font-size:0.75rem; max-width:180px; word-break:break-all;">{{.State.LastError}}</span></div>
+    {{end}}
+    {{if and .DiscoveryHasStats .DiscoveryError}}
+    <div class="kv"><span class="k">Discovery error</span>
+      <span class="v err" style="font-size:0.75rem; max-width:180px; word-break:break-all;">{{.DiscoveryError}}</span></div>
     {{end}}
   </div>
 


### PR DESCRIPTION
## Summary

- Adds `discovery.Status` struct tracking `configured_port`, `running`, `healthy`, `last_error`, `last_request_at`, `last_response_at`, and `response_count`.
- `Responder.GetStatus()` returns a thread-safe snapshot at any time.
- `Run()` records bind failure immediately, so health is visible before any HTTP request arrives; a clear error is already logged via the existing `logger.Error("discovery fatal error")` call in `main.go`.
- `web.Handler.WithDiscovery(fn)` registers the status getter.
- `GET /status.json` embeds a `discovery` object when the getter is wired; omits the field entirely when it is not.
- Dashboard header now shows a live ● running / ● not running indicator next to the UDP port number.
- Status card gains a "Discovery UDP" row (green = running, red = not running).
- A red error banner appears on the dashboard when discovery is unhealthy, with the bind error text.
- The UI no longer implies discovery is working because a port is configured.

## Validation

```
go test ./internal/discovery ./internal/web   # all pass
go test ./...                                  # all pass
gofmt -w <changed files>                       # no diff
```

New tests:
- `TestDiscovery_GetStatus_HealthyAfterBind` — healthy + response count after a successful probe
- `TestDiscovery_GetStatus_UnhealthyOnBindFailure` — unhealthy + last_error when port is occupied
- `TestDiscovery_GetStatus_RunningFalseAfterStop` — running=false after context cancel
- `TestStatusJSON_DiscoveryField_WhenHealthy` — JSON field present with correct values
- `TestStatusJSON_DiscoveryField_WhenUnhealthy` — last_error propagated
- `TestStatusJSON_NoDiscoveryField_WhenNotWired` — field absent when getter not registered

## Notes / limitations

- The Alpaca `PUT action=status` response (in `internal/alpaca/handlers.go`) does not include discovery status; that endpoint uses `BuildStatusJSON` which is scoped to the Alpaca/device layer. Discovery health is a host-side concern and is intentionally exposed only via `/status.json` and the dashboard.
- `Healthy` remains `true` after a clean context-cancel shutdown, reflecting that the listener was functional; `Running` is set to `false`.

Closes #17