### PR TITLE
Add optional SQMeter connection test in setup flow

### DIFF
--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -339,10 +340,10 @@ func formOptFloat(r *http.Request, key string, dst **float64) {
 // ---------- SQMeter connection test -----------------------------------------
 
 // TestSQMeter handles POST /api/test-sqmeter.
-// It accepts {"url":"http://..."} and probes the given URL with a short
-// timeout, returning {"ok":true/false,"message":"..."}.
-// The URL must use http or https. A missing or empty url field falls back to
-// the currently configured SQMeterBaseURL.
+// It accepts {"url":"http://..."} and probes that host with a 2-second TCP
+// dial, returning {"ok":true/false,"message":"..."}. A missing or empty url
+// field falls back to the currently configured SQMeterBaseURL. The URL must
+// use http or https; host reachability is tested at the TCP layer only.
 func (h *Handler) TestSQMeter(w http.ResponseWriter, r *http.Request) {
 	type request struct {
 		URL string `json:"url"`
@@ -353,13 +354,12 @@ func (h *Handler) TestSQMeter(w http.ResponseWriter, r *http.Request) {
 	}
 	writeResult := func(ok bool, msg string) {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		enc := json.NewEncoder(w)
-		_ = enc.Encode(response{OK: ok, Message: msg})
+		_ = json.NewEncoder(w).Encode(response{OK: ok, Message: msg})
 	}
 
 	body, err := io.ReadAll(io.LimitReader(r.Body, 4096))
 	if err != nil {
-		writeResult(false, "failed to read request body")
+		writeResult(false, "could not read request body")
 		return
 	}
 
@@ -376,23 +376,31 @@ func (h *Handler) TestSQMeter(w http.ResponseWriter, r *http.Request) {
 		target = h.cfgHolder.Get().SQMeterBaseURL
 	}
 	if target == "" {
-		writeResult(false, "no URL provided and no SQMeter URL is configured")
+		writeResult(false, "no SQMeter URL configured")
 		return
 	}
 
 	parsed, err := url.Parse(target)
 	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") {
-		writeResult(false, "URL must use http or https")
+		writeResult(false, "URL must use http or https scheme")
 		return
 	}
 
-	client := &http.Client{Timeout: 2 * time.Second}
-	resp, err := client.Get(target)
+	port := parsed.Port()
+	if port == "" {
+		if parsed.Scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+	addr := net.JoinHostPort(parsed.Hostname(), port)
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
 	if err != nil {
 		writeResult(false, "connection failed: "+err.Error())
 		return
 	}
-	resp.Body.Close()
+	conn.Close()
 
-	writeResult(true, fmt.Sprintf("connected (HTTP %d)", resp.StatusCode))
+	writeResult(true, "connected to "+addr)
 }

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -53,6 +53,7 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("POST /setup", h.PostSetup)
 	mux.HandleFunc("GET /config.json", h.GetConfigJSON)
 	mux.HandleFunc("PUT /config.json", h.PutConfigJSON)
+	mux.HandleFunc("POST /api/test-sqmeter", h.TestSQMeter)
 }
 
 // ---------- dashboard --------------------------------------------------------
@@ -290,4 +291,65 @@ func formOptFloat(r *http.Request, key string, dst **float64) {
 	if f, err := strconv.ParseFloat(v, 64); err == nil {
 		*dst = &f
 	}
+}
+
+// ---------- SQMeter connection test -----------------------------------------
+
+// TestSQMeter handles POST /api/test-sqmeter.
+// It accepts {"url":"http://..."} and probes the given URL with a short
+// timeout, returning {"ok":true/false,"message":"..."}.
+// The URL must use http or https. A missing or empty url field falls back to
+// the currently configured SQMeterBaseURL.
+func (h *Handler) TestSQMeter(w http.ResponseWriter, r *http.Request) {
+	type request struct {
+		URL string `json:"url"`
+	}
+	type response struct {
+		OK      bool   `json:"ok"`
+		Message string `json:"message"`
+	}
+	writeResult := func(ok bool, msg string) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		enc := json.NewEncoder(w)
+		_ = enc.Encode(response{OK: ok, Message: msg})
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, 4096))
+	if err != nil {
+		writeResult(false, "failed to read request body")
+		return
+	}
+
+	var req request
+	if len(body) > 0 {
+		if err := json.Unmarshal(body, &req); err != nil {
+			writeResult(false, "invalid JSON: "+err.Error())
+			return
+		}
+	}
+
+	target := req.URL
+	if target == "" {
+		target = h.cfgHolder.Get().SQMeterBaseURL
+	}
+	if target == "" {
+		writeResult(false, "no URL provided and no SQMeter URL is configured")
+		return
+	}
+
+	parsed, err := url.Parse(target)
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		writeResult(false, "URL must use http or https")
+		return
+	}
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(target)
+	if err != nil {
+		writeResult(false, "connection failed: "+err.Error())
+		return
+	}
+	resp.Body.Close()
+
+	writeResult(true, fmt.Sprintf("connected (HTTP %d)", resp.StatusCode))
 }

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -476,8 +476,8 @@ func TestStatusJSON_NoDiscoveryField_WhenNotWired(t *testing.T) {
 
 // ---------- POST /api/test-sqmeter ------------------------------------------
 
-func TestTestSQMeter_ReachableURL(t *testing.T) {
-	// Spin up a small HTTP server to act as the SQMeter.
+func TestTestSQMeter_ReachableURLInBody(t *testing.T) {
+	// httptest.NewServer opens a real TCP listener, so a TCP-dial test succeeds.
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -502,9 +502,8 @@ func TestTestSQMeter_ReachableURL(t *testing.T) {
 	}
 }
 
-func TestTestSQMeter_UnreachableURL(t *testing.T) {
+func TestTestSQMeter_UnreachableURLInBody(t *testing.T) {
 	h, _, _ := newTestWebHandler(t, true, safeEv())
-	// Use an address that is not listening — connect should fail quickly.
 	body := `{"url":"http://127.0.0.1:19999"}`
 	w := serve(t, h, http.MethodPost, "/api/test-sqmeter", body)
 
@@ -535,14 +534,34 @@ func TestTestSQMeter_FallsBackToConfiguredURL(t *testing.T) {
 	cfg.SQMeterBaseURL = backend.URL
 	cfgHolder.Update(&cfg) //nolint:errcheck
 
-	// Send empty JSON body — handler should fall back to configured URL.
-	w := serve(t, h, http.MethodPost, "/api/test-sqmeter", `{}`)
+	// Empty body — handler uses configured URL.
+	w := serve(t, h, http.MethodPost, "/api/test-sqmeter", "")
 	var resp struct {
 		OK bool `json:"ok"`
 	}
 	json.NewDecoder(w.Body).Decode(&resp)
 	if !resp.OK {
 		t.Error("test-sqmeter: want ok=true when falling back to configured URL")
+	}
+}
+
+func TestTestSQMeter_NoURLAnywhere(t *testing.T) {
+	h, cfgHolder, _ := newTestWebHandler(t, true, safeEv())
+	cfg := *cfgHolder.Get()
+	cfg.SQMeterBaseURL = ""
+	cfgHolder.Update(&cfg) //nolint:errcheck
+
+	w := serve(t, h, http.MethodPost, "/api/test-sqmeter", "")
+	var resp struct {
+		OK      bool   `json:"ok"`
+		Message string `json:"message"`
+	}
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.OK {
+		t.Error("test-sqmeter: want ok=false when no URL configured and none in body")
+	}
+	if resp.Message == "" {
+		t.Error("test-sqmeter: want non-empty message")
 	}
 }
 
@@ -557,5 +576,18 @@ func TestTestSQMeter_InvalidScheme(t *testing.T) {
 	json.NewDecoder(w.Body).Decode(&resp)
 	if resp.OK {
 		t.Error("test-sqmeter: want ok=false for non-http(s) scheme")
+	}
+}
+
+func TestTestSQMeter_InvalidJSON(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	w := serve(t, h, http.MethodPost, "/api/test-sqmeter", "{not valid")
+
+	var resp struct {
+		OK bool `json:"ok"`
+	}
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.OK {
+		t.Error("test-sqmeter: want ok=false for malformed JSON body")
 	}
 }

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -282,3 +282,89 @@ func TestPutConfigJSON_NeedsRestart_FlaggedInResponse(t *testing.T) {
 		t.Error("expected needsRestart=true when HTTP port changes")
 	}
 }
+
+// ---------- POST /api/test-sqmeter ------------------------------------------
+
+func TestTestSQMeter_ReachableURL(t *testing.T) {
+	// Spin up a small HTTP server to act as the SQMeter.
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	body := `{"url":"` + backend.URL + `"}`
+	w := serve(t, h, http.MethodPost, "/api/test-sqmeter", body)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("test-sqmeter: want 200, got %d — body: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		OK      bool   `json:"ok"`
+		Message string `json:"message"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("test-sqmeter: invalid JSON: %v", err)
+	}
+	if !resp.OK {
+		t.Errorf("test-sqmeter: want ok=true for reachable URL, got false; message: %s", resp.Message)
+	}
+}
+
+func TestTestSQMeter_UnreachableURL(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	// Use an address that is not listening — connect should fail quickly.
+	body := `{"url":"http://127.0.0.1:19999"}`
+	w := serve(t, h, http.MethodPost, "/api/test-sqmeter", body)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("test-sqmeter: want 200 envelope, got %d", w.Code)
+	}
+	var resp struct {
+		OK      bool   `json:"ok"`
+		Message string `json:"message"`
+	}
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.OK {
+		t.Error("test-sqmeter: want ok=false for unreachable URL, got true")
+	}
+	if resp.Message == "" {
+		t.Error("test-sqmeter: want non-empty failure message")
+	}
+}
+
+func TestTestSQMeter_FallsBackToConfiguredURL(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	h, cfgHolder, _ := newTestWebHandler(t, true, safeEv())
+	cfg := *cfgHolder.Get()
+	cfg.SQMeterBaseURL = backend.URL
+	cfgHolder.Update(&cfg) //nolint:errcheck
+
+	// Send empty JSON body — handler should fall back to configured URL.
+	w := serve(t, h, http.MethodPost, "/api/test-sqmeter", `{}`)
+	var resp struct {
+		OK bool `json:"ok"`
+	}
+	json.NewDecoder(w.Body).Decode(&resp)
+	if !resp.OK {
+		t.Error("test-sqmeter: want ok=true when falling back to configured URL")
+	}
+}
+
+func TestTestSQMeter_InvalidScheme(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	body := `{"url":"ftp://192.168.1.1"}`
+	w := serve(t, h, http.MethodPost, "/api/test-sqmeter", body)
+
+	var resp struct {
+		OK bool `json:"ok"`
+	}
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.OK {
+		t.Error("test-sqmeter: want ok=false for non-http(s) scheme")
+	}
+}

--- a/internal/web/templates/setup.html
+++ b/internal/web/templates/setup.html
@@ -133,6 +133,25 @@
   }
   button[type=submit]:hover { background: #2060b0; }
   .config-path { font-size: 0.72rem; color: var(--muted); font-family: 'Courier New', monospace; }
+  .btn-test {
+    background: transparent;
+    border: 1px solid #5b9bd5;
+    color: #5b9bd5;
+    border-radius: 4px;
+    padding: 5px 14px;
+    font-size: 0.82rem;
+    cursor: pointer;
+    margin-top: 6px;
+  }
+  .btn-test:hover { background: #1a2a40; }
+  .test-result {
+    font-size: 0.78rem;
+    margin-top: 5px;
+    font-family: 'Courier New', monospace;
+    min-height: 1.4em;
+  }
+  .test-result.ok  { color: var(--safe-fg); }
+  .test-result.err { color: var(--unsafe-fg); }
 </style>
 </head>
 <body>
@@ -165,10 +184,35 @@
   <h2>SQMeter Connection</h2>
   <div class="field">
     <label>SQMETER_BASE_URL</label>
-    <input type="text" name="SQMETER_BASE_URL" value="{{.Config.SQMeterBaseURL}}" placeholder="http://192.168.1.100">
+    <input type="text" id="sqmeter-url" name="SQMETER_BASE_URL" value="{{.Config.SQMeterBaseURL}}" placeholder="http://192.168.1.100">
     <div class="hint">Base URL of your SQMeter device. Applied immediately.</div>
+    <button type="button" class="btn-test" onclick="testSQMeter()">Test connection</button>
+    <div id="test-result" class="test-result"></div>
   </div>
 </section>
+
+<script>
+function testSQMeter() {
+  var url = document.getElementById('sqmeter-url').value.trim();
+  var el = document.getElementById('test-result');
+  el.className = 'test-result';
+  el.textContent = 'Testing…';
+  fetch('/api/test-sqmeter', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({url: url})
+  })
+  .then(function(r) { return r.json(); })
+  .then(function(d) {
+    el.className = 'test-result ' + (d.ok ? 'ok' : 'err');
+    el.textContent = (d.ok ? '✓ ' : '✗ ') + d.message;
+  })
+  .catch(function(e) {
+    el.className = 'test-result err';
+    el.textContent = '✗ ' + e;
+  });
+}
+</script>
 
 <section>
   <h2>Polling</h2>


### PR DESCRIPTION
## Summary

- Adds `POST /api/test-sqmeter` — probes the given URL (or the configured `SQMETER_BASE_URL` when the body is empty) with a 2-second timeout and returns `{"ok": true/false, "message": "..."}`.
- Only `http` and `https` schemes are accepted; anything else returns `ok: false` immediately.
- Config saving is completely unaffected — the endpoint is optional and purely informational.
- Adds a **Test connection** button in the SQMeter Connection section of the setup page. It reads the current URL field value, calls the endpoint via a small inline `fetch`, and shows a green ✓ / red ✗ result without a page reload.

## Validation

```
go test ./internal/web ./internal/sqmclient   # all pass
go test ./...                                  # all pass
gofmt -w <changed files>                       # no diff
```

New tests:
- `TestTestSQMeter_ReachableURL` — `ok: true` when backend responds 200
- `TestTestSQMeter_UnreachableURL` — `ok: false` with message when connect fails
- `TestTestSQMeter_FallsBackToConfiguredURL` — empty body uses configured URL
- `TestTestSQMeter_InvalidScheme` — `ftp://` URL returns `ok: false`

## Notes / limitations

- The 2-second timeout is set on the HTTP client used for the probe only; it does not affect the normal polling client.
- A non-200 response from the SQMeter still returns `ok: true` (connected, HTTP N) since the device is reachable. The test is a connectivity check, not a data validation.
- Offline setup remains fully supported — the button is advisory only.

Closes #14