### PR TITLE
Add gosec security scanning to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,11 @@ jobs:
       - name: Vet
         run: go vet ./...
 
+      - name: Security scan (gosec)
+        run: |
+          go install github.com/securego/gosec/v2/cmd/gosec@latest
+          ~/go/bin/gosec ./...
+
       - name: Test (race detector)
         run: go test ./... -race -count=1
 

--- a/cmd/sqmeter-alpaca-safetymonitor/main.go
+++ b/cmd/sqmeter-alpaca-safetymonitor/main.go
@@ -285,7 +285,7 @@ func main() {
 		go func() {
 			sig := <-sigCh
 			fmt.Fprintf(os.Stderr, "\nreceived %s, stopping...\n", sig)
-			s.Stop() //nolint:errcheck
+			s.Stop() /* #nosec G104 -- shutdown call; error cannot be acted on during signal handling */ //nolint:errcheck
 		}()
 	}
 
@@ -298,7 +298,7 @@ func main() {
 // ---------- helpers ----------------------------------------------------------
 
 func loadOrCreateUUID(path string) (string, error) {
-	if data, err := os.ReadFile(path); err == nil {
+	if data, err := os.ReadFile(path); err == nil { // #nosec G304 -- path comes from the --config CLI flag, which the operator controls
 		u := strings.TrimSpace(string(data))
 		if len(u) == 36 {
 			return u, nil
@@ -342,11 +342,11 @@ func openBrowser(url string) {
 	var cmd *exec.Cmd
 	switch runtime.GOOS {
 	case "windows":
-		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url) // #nosec G204 -- executable is hardcoded; url is the configured listen address, not user input
 	case "darwin":
-		cmd = exec.Command("open", url)
+		cmd = exec.Command("open", url) // #nosec G204 -- executable is hardcoded; url is the configured listen address, not user input
 	default:
-		cmd = exec.Command("xdg-open", url)
+		cmd = exec.Command("xdg-open", url) // #nosec G204 -- executable is hardcoded; url is the configured listen address, not user input
 	}
 	_ = cmd.Start()
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,7 +62,7 @@ func Load(path string) (*Config, error) {
 	cfg := Defaults()
 
 	if path != "" {
-		data, err := os.ReadFile(path)
+		data, err := os.ReadFile(path) // #nosec G304 -- path comes from the --config CLI flag, which the operator controls
 		if err != nil && !os.IsNotExist(err) {
 			return nil, fmt.Errorf("reading config file %q: %w", path, err)
 		}

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -74,7 +74,7 @@ func (r *Responder) Run(ctx context.Context) error {
 
 	go func() {
 		<-ctx.Done()
-		conn.Close()
+		conn.Close() /* #nosec G104 -- closing UDP socket on shutdown; error cannot be meaningfully handled here */ //nolint:errcheck
 	}()
 
 	reply, _ := json.Marshal(map[string]int{"AlpacaPort": r.httpPort})

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -514,7 +514,7 @@ func (h *Handler) TestSQMeter(w http.ResponseWriter, r *http.Request) {
 		writeResult(false, "connection failed: "+err.Error())
 		return
 	}
-	conn.Close()
+	conn.Close() /* #nosec G104 -- TCP probe; connection immediately discarded; close error is irrelevant */ //nolint:errcheck
 
 	writeResult(true, "connected to "+addr)
 }


### PR DESCRIPTION
## Summary

- Adds a **Security scan (gosec)** step to the `lint-and-test` job in `ci.yml`, running after `go vet` on every push to `main` and every pull request
- Installs gosec at latest via `go install` and runs `~/go/bin/gosec ./...`
- CI fails on any unsuppressed finding (gosec default behaviour)

## Suppressions added

All suppressions use inline `// #nosec Gxxx -- <reason>` or `/* #nosec Gxxx -- <reason> */` comments with explicit justification:

| Rule | Location | Reason |
|------|----------|--------|
| G304 | `internal/config/config.go:65` | File path comes from the `--config` CLI flag; the operator controls this value |
| G304 | `cmd/.../main.go:301` | Same — UUID file path is derived from the operator-supplied `--config` flag |
| G204 | `cmd/.../main.go:345,347,349` | `openBrowser`: executables are hardcoded OS builtins (`rundll32`, `open`, `xdg-open`); only the URL (configured listen address) is variable |
| G104 | `internal/discovery/discovery.go:77` | `conn.Close()` on context cancellation; close error during shutdown cannot be meaningfully handled |
| G104 | `internal/web/handlers.go:517` | TCP probe that discards the connection immediately; close error is irrelevant after a successful dial |
| G104 | `cmd/.../main.go:288` | `s.Stop()` in signal handler goroutine; error cannot be acted on during shutdown |

## Local gosec output (clean)

```
Results:

Summary:
  Gosec  : dev
  Files  : 14
  Lines  : 2165
  Nosec  : 8
  Issues : 0
```

Closes #33