### PR TITLE
Fix ConformU bad API path handling and transaction ID casing

### DIFF
--- a/internal/alpaca/conformu_test.go
+++ b/internal/alpaca/conformu_test.go
@@ -1,0 +1,149 @@
+package alpaca_test
+
+// ConformU bad-path and transaction-ID casing tests.
+//
+// ConformU probes malformed Alpaca URLs and expects a non-200 response that
+// does not contain an HTML body.  It also sends Alpaca transaction parameters
+// with non-canonical casing and expects the IDs to be echoed back correctly.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"sqmeter-alpaca-safetymonitor/internal/alpaca"
+)
+
+// newMux returns a fully registered ServeMux for the given handler.
+func newMux(h *alpaca.Handler) *http.ServeMux {
+	mux := http.NewServeMux()
+	h.Register(mux)
+	return mux
+}
+
+// serve issues a GET request against mux and returns the recorder.
+func serveGET(mux *http.ServeMux, path string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	return w
+}
+
+// assertNon200AndNotHTML checks that the response is a client-error status and
+// that the body does not look like an HTML page.
+func assertNon200AndNotHTML(t *testing.T, label string, w *httptest.ResponseRecorder) {
+	t.Helper()
+	code := w.Code
+	if code < 400 || code >= 600 {
+		t.Errorf("%s: want 4xx status, got %d", label, code)
+	}
+	body := w.Body.String()
+	if strings.Contains(body, "<html") || strings.Contains(body, "<!DOCTYPE") {
+		t.Errorf("%s: response body looks like HTML (status %d)", label, code)
+	}
+}
+
+// ---------- bad-path tests ---------------------------------------------------
+
+func TestBadPath_WrongDeviceTypeCaps(t *testing.T) {
+	// /api/v1/SAFETYMONITOR/0/description — capitalised device type
+	mux := newMux(newTestHandler(true, safeState()))
+	w := serveGET(mux, "/api/v1/SAFETYMONITOR/0/description")
+	assertNon200AndNotHTML(t, "SAFETYMONITOR caps", w)
+}
+
+func TestBadPath_BadDeviceType(t *testing.T) {
+	// /api/v1/baddevicetype/0/description — completely wrong device type
+	mux := newMux(newTestHandler(true, safeState()))
+	w := serveGET(mux, "/api/v1/baddevicetype/0/description")
+	assertNon200AndNotHTML(t, "baddevicetype", w)
+}
+
+func TestBadPath_NegativeDeviceNumber(t *testing.T) {
+	// /api/v1/safetymonitor/-1/description
+	mux := newMux(newTestHandler(true, safeState()))
+	w := serveGET(mux, "/api/v1/safetymonitor/-1/description")
+	assertNon200AndNotHTML(t, "device number -1", w)
+}
+
+func TestBadPath_LargeDeviceNumber(t *testing.T) {
+	// /api/v1/safetymonitor/99999/description — out-of-range device number
+	mux := newMux(newTestHandler(true, safeState()))
+	w := serveGET(mux, "/api/v1/safetymonitor/99999/description")
+	assertNon200AndNotHTML(t, "device number 99999", w)
+}
+
+func TestBadPath_AlphaDeviceNumber(t *testing.T) {
+	// /api/v1/safetymonitor/A/description — non-numeric device number
+	mux := newMux(newTestHandler(true, safeState()))
+	w := serveGET(mux, "/api/v1/safetymonitor/A/description")
+	assertNon200AndNotHTML(t, "device number A", w)
+}
+
+func TestBadPath_TruncatedMethod(t *testing.T) {
+	// /api/v1/safetymonitor/0/descrip — typo in method name
+	mux := newMux(newTestHandler(true, safeState()))
+	w := serveGET(mux, "/api/v1/safetymonitor/0/descrip")
+	assertNon200AndNotHTML(t, "descrip typo", w)
+}
+
+// ---------- ClientTransactionID casing tests ---------------------------------
+
+func TestClientTransactionID_LowerCase(t *testing.T) {
+	// ConformU may send "clienttransactionid" in lowercase
+	h := newTestHandler(true, safeState())
+	mux := newMux(h)
+	req := httptest.NewRequest(http.MethodGet, "/management/apiversions?clienttransactionid=77", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	var env struct {
+		ClientTransactionID uint32 `json:"ClientTransactionID"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if env.ClientTransactionID != 77 {
+		t.Errorf("ClientTransactionID: want 77, got %d", env.ClientTransactionID)
+	}
+}
+
+func TestClientTransactionID_UpperCase(t *testing.T) {
+	// ConformU may also send "CLIENTTRANSACTIONID" in uppercase
+	h := newTestHandler(true, safeState())
+	mux := newMux(h)
+	req := httptest.NewRequest(http.MethodGet, "/management/apiversions?CLIENTTRANSACTIONID=99", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	var env struct {
+		ClientTransactionID uint32 `json:"ClientTransactionID"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if env.ClientTransactionID != 99 {
+		t.Errorf("ClientTransactionID: want 99, got %d", env.ClientTransactionID)
+	}
+}
+
+func TestClientTransactionID_MixedCase_PUT(t *testing.T) {
+	// Case-insensitive parsing for PUT form bodies
+	h := newTestHandler(true, safeState())
+	mux := newMux(h)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/safetymonitor/0/connect",
+		strings.NewReader("ClientID=1&clienttransactionid=55"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	var resp alpaca.VoidResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.ClientTransactionID != 55 {
+		t.Errorf("ClientTransactionID: want 55, got %d", resp.ClientTransactionID)
+	}
+}

--- a/internal/alpaca/handlers.go
+++ b/internal/alpaca/handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -67,6 +68,10 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("PUT /api/v1/safetymonitor/0/commandblind", h.PutCommandNotImpl)
 	mux.HandleFunc("PUT /api/v1/safetymonitor/0/commandbool", h.PutCommandNotImpl)
 	mux.HandleFunc("PUT /api/v1/safetymonitor/0/commandstring", h.PutCommandNotImpl)
+
+	// Catch-all for any unrecognised /api/ path. This prevents the dashboard
+	// handler from returning HTML for malformed or unsupported Alpaca URLs.
+	mux.HandleFunc("/api/", h.APINotFound)
 }
 
 // ---------- helpers ----------------------------------------------------------
@@ -80,12 +85,37 @@ func writeJSON(w http.ResponseWriter, v any) {
 	}
 }
 
+// queryGetCI returns the first value for key from query params using a
+// case-insensitive key match, allowing ConformU to send e.g.
+// "clienttransactionid" or "CLIENTTRANSACTIONID" and still be parsed.
+func queryGetCI(q map[string][]string, key string) string {
+	keyLower := strings.ToLower(key)
+	for k, vals := range q {
+		if strings.ToLower(k) == keyLower && len(vals) > 0 {
+			return vals[0]
+		}
+	}
+	return ""
+}
+
+// formGetCI returns the first value for key from a parsed form using a
+// case-insensitive key match.
+func formGetCI(r *http.Request, key string) string {
+	keyLower := strings.ToLower(key)
+	for k, vals := range r.Form {
+		if strings.ToLower(k) == keyLower && len(vals) > 0 {
+			return vals[0]
+		}
+	}
+	return ""
+}
+
 func parseGetParams(r *http.Request) (clientID, clientTxID uint32) {
 	q := r.URL.Query()
-	if v, err := strconv.ParseUint(q.Get("ClientID"), 10, 32); err == nil {
+	if v, err := strconv.ParseUint(queryGetCI(q, "ClientID"), 10, 32); err == nil {
 		clientID = uint32(v)
 	}
-	if v, err := strconv.ParseUint(q.Get("ClientTransactionID"), 10, 32); err == nil {
+	if v, err := strconv.ParseUint(queryGetCI(q, "ClientTransactionID"), 10, 32); err == nil {
 		clientTxID = uint32(v)
 	}
 	return
@@ -93,13 +123,26 @@ func parseGetParams(r *http.Request) (clientID, clientTxID uint32) {
 
 func parsePutParams(r *http.Request) (clientID, clientTxID uint32) {
 	_ = r.ParseForm()
-	if v, err := strconv.ParseUint(r.FormValue("ClientID"), 10, 32); err == nil {
+	if v, err := strconv.ParseUint(formGetCI(r, "ClientID"), 10, 32); err == nil {
 		clientID = uint32(v)
 	}
-	if v, err := strconv.ParseUint(r.FormValue("ClientTransactionID"), 10, 32); err == nil {
+	if v, err := strconv.ParseUint(formGetCI(r, "ClientTransactionID"), 10, 32); err == nil {
 		clientTxID = uint32(v)
 	}
 	return
+}
+
+// APINotFound handles any /api/ path that did not match a registered Alpaca
+// route. It returns a 404 Alpaca-style JSON error so that ConformU bad-path
+// tests do not receive an HTML dashboard response.
+func (h *Handler) APINotFound(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(http.StatusNotFound)
+	resp := VoidResponse{
+		ErrorNumber:  ErrUnspecified,
+		ErrorMessage: "not found: " + r.URL.Path,
+	}
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 func okResp[T any](clientTxID, serverTxID uint32, value T) Response[T] {


### PR DESCRIPTION
## Summary
- Prevents malformed /api/ Alpaca routes from falling through to the dashboard.
- Parses Alpaca transaction parameters case-insensitively.
- Adds tests for ConformU bad-path and ClientTransactionID casing cases.

Addresses #34.

## Validation
- `go test ./internal/alpaca ./internal/web`
- `go test ./...`

## Notes
- Real ConformU validation should be rerun against the Windows service build.