### PR TITLE
Define safe installer upgrade and config migration strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
           $PSNativeCommandUseErrorActionPreference = $true
           $exe = ".\dist\sqmeter-alpaca-safetymonitor-windows-amd64.exe"
 
-          $versionOutput = & $exe --version
+          $versionOutput = (& $exe --version) -join "`n"
           $versionOutput
           if ($versionOutput -notmatch "ci") {
             throw "version output did not include the CI version"

--- a/README.md
+++ b/README.md
@@ -54,21 +54,53 @@ The supported upgrade path is **install over the existing version** — you do n
 | Stop service | The existing service is stopped and unregistered before the binary is replaced. |
 | Replace binary | The new `sqmeter-alpaca-safetymonitor.exe` is written to the install directory. |
 | Re-register service | The service is registered against the new binary and started. |
-| Config preserved | `config.json` and `device-uuid.txt` are not modified by the installer. |
+| Config preserved | `config.json` and `device-uuid.txt` in `%ProgramData%\SQMeter SafetyMonitor\` are not modified by the installer. |
 
 ### Rollback
 
 To roll back to a previous version, run the older installer over the current installation using the same install-over-existing process. Your `config.json` is unaffected.
 
+### Config schema migration
+
+When a new version introduces a config schema change, the binary migrates the in-memory config automatically on startup. If the on-disk file has an older `config_version`, the binary:
+
+1. Creates a timestamped backup (e.g. `config.20240115T120000Z.bak`) beside `config.json`.
+2. Rewrites `config.json` with the migrated settings.
+
+If the config file has a `config_version` newer than the binary supports, the service will not start — upgrade the binary to match.
+
 ### Automatic updates
 
-Automatic update checking is **not implemented**. New releases are announced on [GitHub Releases](../../releases). A future tray icon may offer a "check for updates" link to that page.
+Automatic update checking is **not implemented**. New releases are published on [GitHub Releases](../../releases). A future tray icon may offer a "check for updates" link to that page.
+
+Run `sqmeter-alpaca-safetymonitor.exe --version` to see the current version and the releases URL.
 
 ---
 
 ## Configuration
 
-Configuration is managed through the web setup UI at `http://localhost:11111/setup`, which reads and writes `config.json` next to the executable.
+Configuration is managed through the web setup UI at `http://localhost:11111/setup`.
+
+### Config file location
+
+| Platform | Default path |
+|----------|-------------|
+| Windows | `%ProgramData%\SQMeter SafetyMonitor\config.json` |
+| Linux / macOS | `<directory containing the executable>/config.json` |
+
+On Windows the config file lives in `%ProgramData%` (typically `C:\ProgramData\SQMeter SafetyMonitor\config.json`), not beside the `.exe`. This keeps the install directory under `Program Files` free of mutable user data.
+
+Override the path at any time with `--config <path>`.
+
+#### Migrating from an older installation
+
+Versions prior to this release stored `config.json` beside the executable in the install directory (e.g. `C:\Program Files\SQMeter Alpaca SafetyMonitor\config.json`). To migrate manually:
+
+1. Stop the service: `sqmeter-alpaca-safetymonitor.exe --service stop`
+2. Copy `config.json` from the install directory to `%ProgramData%\SQMeter SafetyMonitor\`.
+3. Start the service: `sqmeter-alpaca-safetymonitor.exe --service start`
+
+If no config exists in `%ProgramData%`, the service starts with built-in defaults and the setup page opens automatically.
 
 You can also edit `config.json` directly:
 
@@ -114,7 +146,7 @@ The only environment variable that influences runtime behaviour is `LOG_LEVEL` (
 
 | Flag | Description |
 |------|-------------|
-| `--config <path>` | Path to the JSON config file (default: `config.json` next to the exe) |
+| `--config <path>` | Path to the JSON config file (default: `%ProgramData%\SQMeter SafetyMonitor\config.json` on Windows, `<exedir>/config.json` on other platforms) |
 | `--write-default-config` | Write default settings to `--config` path and exit |
 | `--check-config` | Validate the config file and exit |
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,36 @@ It answers one question: **"Is it safe for the observatory to operate right now?
 
 ---
 
+## Upgrading
+
+The supported upgrade path is **install over the existing version** — you do not need to uninstall first.
+
+### Steps
+
+1. Download the new installer (`sqmeter-alpaca-safetymonitor-setup-vX.Y.Z.exe`) from [Releases](../../releases).
+2. Run the installer as Administrator.
+3. The installer automatically stops and unregisters the running service before replacing the binary, then re-registers and restarts it.
+4. Your `config.json` is never touched by the installer — settings are always preserved across upgrades.
+
+### What the installer does during an upgrade
+
+| Step | Details |
+|------|---------|
+| Stop service | The existing service is stopped and unregistered before the binary is replaced. |
+| Replace binary | The new `sqmeter-alpaca-safetymonitor.exe` is written to the install directory. |
+| Re-register service | The service is registered against the new binary and started. |
+| Config preserved | `config.json` and `device-uuid.txt` are not modified by the installer. |
+
+### Rollback
+
+To roll back to a previous version, run the older installer over the current installation using the same install-over-existing process. Your `config.json` is unaffected.
+
+### Automatic updates
+
+Automatic update checking is **not implemented**. New releases are announced on [GitHub Releases](../../releases). A future tray icon may offer a "check for updates" link to that page.
+
+---
+
 ## Configuration
 
 Configuration is managed through the web setup UI at `http://localhost:11111/setup`, which reads and writes `config.json` next to the executable.

--- a/cmd/sqmeter-alpaca-safetymonitor/main.go
+++ b/cmd/sqmeter-alpaca-safetymonitor/main.go
@@ -89,6 +89,15 @@ func (p *program) run(ctx context.Context, interactive bool) {
 		"bind", cfg.AlpacaHTTPBind,
 	)
 
+	// If the on-disk config predates the current schema version, rewrite it
+	// with a timestamped backup. Best-effort: a failure here is logged but
+	// does not prevent startup (the migrated config is already in memory).
+	if backupPath, migErr := config.PersistMigrationIfNeeded(p.cfgPath, cfg); backupPath != "" {
+		logger.Info("config schema upgraded", "backup", backupPath)
+	} else if migErr != nil {
+		logger.Warn("could not persist migrated config", "error", migErr)
+	}
+
 	if config.IsWideOpen(cfg.AlpacaHTTPBind) {
 		logger.Warn("service is bound to a non-loopback address; reachable from the network",
 			"bind", cfg.AlpacaHTTPBind,
@@ -186,14 +195,15 @@ func (p *program) run(ctx context.Context, interactive bool) {
 // ---------- entry point ------------------------------------------------------
 
 func main() {
-	// Default config paths to the directory containing the executable so the
-	// service always finds its config regardless of working directory.
+	// Default config and data paths use the platform-appropriate location.
+	// On Windows this is %ProgramData%\SQMeter SafetyMonitor\; on other
+	// platforms the directory containing the executable is used.
 	exe, _ := os.Executable()
 	exeDir := filepath.Dir(exe)
 
 	var (
-		cfgPath            = flag.String("config", filepath.Join(exeDir, "config.json"), "path to JSON config file")
-		uuidPath           = flag.String("uuid-file", filepath.Join(exeDir, "device-uuid.txt"), "path to persist stable device UUID")
+		cfgPath            = flag.String("config", config.DefaultConfigPath(exeDir), "path to JSON config file")
+		uuidPath           = flag.String("uuid-file", config.DefaultUUIDPath(exeDir), "path to persist stable device UUID")
 		svcCmd             = flag.String("service", "", "manage the system service: install|uninstall|start|stop|status")
 		showVersion        = flag.Bool("version", false, "print version and exit")
 		writeDefaultConfig = flag.Bool("write-default-config", false, "write default config to --config path and exit")
@@ -204,6 +214,7 @@ func main() {
 
 	if *showVersion {
 		fmt.Printf("sqmeter-alpaca-safetymonitor %s (commit %s, built %s)\n", version, commit, date)
+		fmt.Printf("Latest releases: %s\n", config.ReleasesURL)
 		return
 	}
 

--- a/installer/setup.iss
+++ b/installer/setup.iss
@@ -1,5 +1,17 @@
 ; SQMeter Alpaca SafetyMonitor - Inno Setup installer script
 ; Build with: ISCC.exe /DAppVersion=1.2.3 setup.iss
+;
+; Upgrade behaviour (install over an existing version):
+;   1. BeforeInstall hook stops and uninstalls the running service.
+;   2. Installer replaces the binary.
+;   3. [Run] re-installs and restarts the service.
+;   4. config.json is NOT in [Files] and is never touched by the installer,
+;      so user configuration is always preserved across upgrades.
+;   5. device-uuid.txt is similarly left untouched.
+;
+; Automatic update checking is not implemented. Users upgrade by downloading
+; the new installer from GitHub Releases and running it over the existing
+; installation.
 
 #ifndef AppVersion
   #define AppVersion "dev"
@@ -36,16 +48,24 @@ MinVersion=10.0
 Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Files]
-; Main binary - placed in the install directory
-Source: "bin\{#ExeName}"; DestDir: "{app}"; Flags: ignoreversion
+; Main binary - placed in the install directory.
+; BeforeInstall stops and uninstalls any existing service so the binary is
+; not locked when the installer tries to replace it (Windows locks running
+; executables). On a fresh install the old binary does not exist and the
+; stop/uninstall calls fail silently, which is harmless.
+Source: "bin\{#ExeName}"; DestDir: "{app}"; Flags: ignoreversion; \
+  BeforeInstall: StopExistingService
 
 [Run]
-; Install the Windows service (registered against the installed exe path)
+; Re-install the Windows service against the new binary path.
+; On a fresh install this registers the service for the first time.
+; On an upgrade the old service was uninstalled by BeforeInstall, so this
+; is always a clean registration.
 Filename: "{app}\{#ExeName}"; Parameters: "--service install"; \
   Flags: runhidden waituntilterminated; \
   StatusMsg: "Installing service..."
 
-; Start the service so it is immediately available
+; Start the service so it is immediately available after install or upgrade.
 Filename: "{app}\{#ExeName}"; Parameters: "--service start"; \
   Flags: runhidden waituntilterminated; \
   StatusMsg: "Starting service..."
@@ -69,3 +89,17 @@ Name: "{group}\Configuration"; \
   Parameters: ""; \
   Comment: "Open SQMeter SafetyMonitor configuration (opens browser)"
 Name: "{group}\Uninstall {#AppName}"; Filename: "{uninstallexe}"
+
+[Code]
+// StopExistingService is called by BeforeInstall on the main binary file entry.
+// It stops and uninstalls the running service so the installer can replace the
+// locked executable. Both calls are best-effort: a non-zero exit code (e.g.
+// service not found on a fresh install) is intentionally ignored.
+procedure StopExistingService;
+var ResultCode: Integer;
+begin
+  Exec(ExpandConstant('{app}\{#ExeName}'), '--service stop', '', SW_HIDE,
+       ewWaitUntilTerminated, ResultCode);
+  Exec(ExpandConstant('{app}\{#ExeName}'), '--service uninstall', '', SW_HIDE,
+       ewWaitUntilTerminated, ResultCode);
+end;

--- a/installer/setup.iss
+++ b/installer/setup.iss
@@ -5,9 +5,22 @@
 ;   1. BeforeInstall hook stops and uninstalls the running service.
 ;   2. Installer replaces the binary.
 ;   3. [Run] re-installs and restarts the service.
-;   4. config.json is NOT in [Files] and is never touched by the installer,
-;      so user configuration is always preserved across upgrades.
-;   5. device-uuid.txt is similarly left untouched.
+;   4. config.json lives in %ProgramData%\SQMeter SafetyMonitor\ and is never
+;      touched by the installer, so user configuration is preserved on upgrade.
+;   5. device-uuid.txt is in the same ProgramData directory and is similarly
+;      left untouched.
+;
+; ProgramData directory:
+;   The binary defaults to %ProgramData%\SQMeter SafetyMonitor\ for config
+;   and the device UUID. The installer creates this directory on fresh install
+;   and writes a default config.json only when one does not already exist.
+;   On upgrade the existing config is always preserved.
+;
+; Uninstall behaviour:
+;   The service is stopped and unregistered. The binary and install-directory
+;   files are removed. The ProgramData directory (config, UUID, logs) is NOT
+;   removed, so user settings survive uninstall. Delete
+;   %ProgramData%\SQMeter SafetyMonitor\ manually if a clean removal is wanted.
 ;
 ; Automatic update checking is not implemented. Users upgrade by downloading
 ; the new installer from GitHub Releases and running it over the existing
@@ -23,6 +36,8 @@
 #define ServiceName  "SQMeterAlpacaSafetyMonitor"
 #define ExeName      "sqmeter-alpaca-safetymonitor.exe"
 #define SetupBase    "sqmeter-alpaca-safetymonitor-setup"
+; AppDataDir must match config.AppDataDirName in internal/config/paths.go.
+#define AppDataDir   "SQMeter SafetyMonitor"
 
 [Setup]
 AppId={{E3A7C2B1-4F8D-4E2A-9C3B-1D5F7A8E0B2C}
@@ -47,6 +62,11 @@ MinVersion=10.0
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
 
+[Dirs]
+; Create the ProgramData directory that the binary uses for config and the
+; device UUID. The directory is not removed on uninstall (preserves user data).
+Name: "{commonappdata}\{#AppDataDir}"; Flags: uninsneveruninstall
+
 [Files]
 ; Main binary - placed in the install directory.
 ; BeforeInstall stops and uninstalls any existing service so the binary is
@@ -57,6 +77,14 @@ Source: "bin\{#ExeName}"; DestDir: "{app}"; Flags: ignoreversion; \
   BeforeInstall: StopExistingService
 
 [Run]
+; Write a default config.json only when no config exists yet (fresh install).
+; On upgrade the existing config in ProgramData is left untouched.
+Filename: "{app}\{#ExeName}"; \
+  Parameters: "--write-default-config"; \
+  Flags: runhidden waituntilterminated; \
+  StatusMsg: "Writing default configuration..."; \
+  Check: not FileExists(ExpandConstant('{commonappdata}\{#AppDataDir}\config.json'))
+
 ; Re-install the Windows service against the new binary path.
 ; On a fresh install this registers the service for the first time.
 ; On an upgrade the old service was uninstalled by BeforeInstall, so this

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,11 @@ import (
 // environment variable that influences runtime behaviour is LOG_LEVEL, which
 // is a process/logging concern and not a configuration file setting.
 type Config struct {
+	// ConfigVersion records which config schema version this file was written
+	// with. Absent in older files (loads as 0, treated as pre-versioning).
+	// The current version is 1. Future breaking schema changes will increment
+	// this and may apply migrations on load.
+	ConfigVersion        int      `json:"config_version,omitempty"`
 	SQMeterBaseURL       string   `json:"SQMETER_BASE_URL"`
 	AlpacaHTTPBind       string   `json:"ALPACA_HTTP_BIND"`
 	AlpacaHTTPPort       int      `json:"ALPACA_HTTP_PORT"`
@@ -31,9 +36,15 @@ type Config struct {
 	LogLevel             string   `json:"LOG_LEVEL"`
 }
 
+// CurrentConfigVersion is the schema version written to new and updated config files.
+// Older configs that predate this field load as version 0 in the raw JSON, but
+// Load stamps them with the current version before returning.
+const CurrentConfigVersion = 1
+
 // Defaults returns a Config populated with safe, conservative defaults.
 func Defaults() *Config {
 	return &Config{
+		ConfigVersion:        CurrentConfigVersion,
 		SQMeterBaseURL:       "http://sqmeter.local",
 		AlpacaHTTPBind:       "127.0.0.1",
 		AlpacaHTTPPort:       11111,
@@ -58,6 +69,11 @@ func Defaults() *Config {
 // Config loading order: defaults -> config file -> validation.
 // The only environment variable applied at runtime is LOG_LEVEL.
 // All other settings must be set in the config file.
+//
+// Configs written before config_version was introduced load as version 0.
+// They are valid and load without error; only the in-memory representation
+// is updated to CurrentConfigVersion. Future schema migrations, if any, will
+// key off the loaded version before stamping it.
 func Load(path string) (*Config, error) {
 	cfg := Defaults()
 
@@ -72,6 +88,10 @@ func Load(path string) (*Config, error) {
 			}
 		}
 	}
+
+	// Stamp the current version so callers always see a versioned config,
+	// even when loading a pre-versioning file (config_version absent → 0).
+	cfg.ConfigVersion = CurrentConfigVersion
 
 	// LOG_LEVEL is the only env var applied at runtime; it is a
 	// process/logging concern rather than an application setting.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,16 +66,18 @@ func Defaults() *Config {
 // Load reads config from path (may be empty) and applies LOG_LEVEL from the
 // environment if set. Returns an error if the file exists but is invalid.
 //
-// Config loading order: defaults -> config file -> validation.
+// Config loading order: defaults -> config file -> migration -> validation.
 // The only environment variable applied at runtime is LOG_LEVEL.
 // All other settings must be set in the config file.
 //
-// Configs written before config_version was introduced load as version 0.
-// They are valid and load without error; only the in-memory representation
-// is updated to CurrentConfigVersion. Future schema migrations, if any, will
-// key off the loaded version before stamping it.
+// Configs written before config_version was introduced load as version 0 and
+// are migrated to CurrentConfigVersion in memory. If the on-disk version is
+// newer than CurrentConfigVersion, Load returns an error. To persist the
+// migrated config back to disk (with a backup), call PersistMigrationIfNeeded
+// after a successful Load.
 func Load(path string) (*Config, error) {
 	cfg := Defaults()
+	loadedVersion := 0 // 0 = pre-versioning file or no file
 
 	if path != "" {
 		data, err := os.ReadFile(path) // #nosec G304 -- path comes from the --config CLI flag, which the operator controls
@@ -86,11 +88,15 @@ func Load(path string) (*Config, error) {
 			if err := json.Unmarshal(data, cfg); err != nil {
 				return nil, fmt.Errorf("parsing config file %q: %w", path, err)
 			}
+			loadedVersion = cfg.ConfigVersion
 		}
 	}
 
-	// Stamp the current version so callers always see a versioned config,
-	// even when loading a pre-versioning file (config_version absent → 0).
+	if err := migrateConfig(cfg, loadedVersion); err != nil {
+		return nil, err
+	}
+
+	// Stamp the current version so callers always see a versioned config.
 	cfg.ConfigVersion = CurrentConfigVersion
 
 	// LOG_LEVEL is the only env var applied at runtime; it is a

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -135,3 +135,52 @@ func TestLoad_MissingURL(t *testing.T) {
 		t.Error("expected error for empty SQMETER_BASE_URL")
 	}
 }
+
+// TestLoad_OldConfigWithoutVersionStillLoads ensures pre-versioning config
+// files (no config_version field) are accepted and loaded as the current version.
+func TestLoad_OldConfigWithoutVersionStillLoads(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	// Simulate a config written before config_version was introduced.
+	old := `{"SQMETER_BASE_URL":"http://old.local","ALPACA_HTTP_PORT":11111}`
+	if err := os.WriteFile(path, []byte(old), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("old config should load without error: %v", err)
+	}
+	if cfg.SQMeterBaseURL != "http://old.local" {
+		t.Errorf("SQMeterBaseURL: want http://old.local, got %q", cfg.SQMeterBaseURL)
+	}
+	if cfg.ConfigVersion != config.CurrentConfigVersion {
+		t.Errorf("ConfigVersion: want %d (current), got %d", config.CurrentConfigVersion, cfg.ConfigVersion)
+	}
+}
+
+// TestDefaults_HasCurrentConfigVersion ensures freshly-written configs always
+// include the current schema version.
+func TestDefaults_HasCurrentConfigVersion(t *testing.T) {
+	cfg := config.Defaults()
+	if cfg.ConfigVersion != config.CurrentConfigVersion {
+		t.Errorf("Defaults() ConfigVersion: want %d, got %d", config.CurrentConfigVersion, cfg.ConfigVersion)
+	}
+}
+
+// TestLoad_ConfigVersionWrittenToNewFile verifies SaveDefault produces a file
+// that, when loaded, carries the current config version.
+func TestLoad_ConfigVersionWrittenToNewFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := config.SaveDefault(path); err != nil {
+		t.Fatalf("SaveDefault: %v", err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.ConfigVersion != config.CurrentConfigVersion {
+		t.Errorf("config_version in saved file: want %d, got %d", config.CurrentConfigVersion, cfg.ConfigVersion)
+	}
+}

--- a/internal/config/holder.go
+++ b/internal/config/holder.go
@@ -2,7 +2,9 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
 )
 
@@ -28,13 +30,16 @@ func (h *Holder) Get() *Config {
 	return h.cfg
 }
 
-// Update validates newCfg, persists it (if a path is set), then atomically
-// replaces the current config.
+// Update validates newCfg, ensures the config directory exists, persists the
+// config (if a path is set), then atomically replaces the current config.
 func (h *Holder) Update(newCfg *Config) error {
 	if err := validate(newCfg); err != nil {
 		return err
 	}
 	if h.path != "" {
+		if err := os.MkdirAll(filepath.Dir(h.path), 0700); err != nil {
+			return fmt.Errorf("creating config directory: %w", err)
+		}
 		if err := saveToFile(newCfg, h.path); err != nil {
 			return err
 		}
@@ -48,8 +53,13 @@ func (h *Holder) Update(newCfg *Config) error {
 // Path returns the config file path this holder is linked to.
 func (h *Holder) Path() string { return h.path }
 
-// SaveDefault writes the default config to path.
+// SaveDefault writes the default config to path, creating parent directories
+// as needed.  This is the correct way to initialise a config at a new location
+// (e.g. %ProgramData%\SQMeter SafetyMonitor\config.json on first install).
 func SaveDefault(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("creating config directory: %w", err)
+	}
 	return saveToFile(Defaults(), path)
 }
 

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -40,7 +40,7 @@ func BackupConfigFile(path string) (string, error) {
 	ext := filepath.Ext(path)
 	base := strings.TrimSuffix(path, ext)
 	backupPath := fmt.Sprintf("%s.%s.bak", base, ts)
-	if err := os.WriteFile(backupPath, data, 0600); err != nil {
+	if err := os.WriteFile(backupPath, data, 0600); err != nil { // #nosec G703 -- backupPath is derived from operator-controlled --config path
 		return "", fmt.Errorf("writing config backup %q: %w", backupPath, err)
 	}
 	return backupPath, nil

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// migrateConfig applies in-memory migrations from fromVersion to
+// CurrentConfigVersion.  It is called by Load with the version read from the
+// file before the current version is stamped.
+//
+// Migration table:
+//
+//	v0 → v1: config_version field introduced; no structural changes needed.
+//
+// To add a future migration, increment CurrentConfigVersion and add a case here.
+func migrateConfig(cfg *Config, fromVersion int) error {
+	if fromVersion > CurrentConfigVersion {
+		return fmt.Errorf(
+			"config_version %d is newer than this binary supports (%d); please upgrade the application",
+			fromVersion, CurrentConfigVersion,
+		)
+	}
+	// v0 → v1: config_version introduced; no field renames or removals.
+	return nil
+}
+
+// BackupConfigFile copies path to a timestamped sibling file of the form
+// <base>.YYYYMMDDTHHMMSSZ.bak and returns the backup file path.
+func BackupConfigFile(path string) (string, error) {
+	data, err := os.ReadFile(path) // #nosec G304 -- path comes from operator-controlled --config flag
+	if err != nil {
+		return "", fmt.Errorf("reading config for backup: %w", err)
+	}
+	ts := time.Now().UTC().Format("20060102T150405Z")
+	ext := filepath.Ext(path)
+	base := strings.TrimSuffix(path, ext)
+	backupPath := fmt.Sprintf("%s.%s.bak", base, ts)
+	if err := os.WriteFile(backupPath, data, 0600); err != nil {
+		return "", fmt.Errorf("writing config backup %q: %w", backupPath, err)
+	}
+	return backupPath, nil
+}
+
+// PersistMigrationIfNeeded reads the current on-disk config version and, when
+// it is older than CurrentConfigVersion, backs up the file and rewrites it
+// with the already-migrated cfg.
+//
+// Returns the backup path when a migration write occurred; returns ("", nil)
+// when no action was needed (file already current, or path is empty).
+//
+// Errors are non-fatal for callers: the migrated config is already in memory
+// and the service can start normally even if the persist step fails.
+func PersistMigrationIfNeeded(path string, cfg *Config) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	data, err := os.ReadFile(path) // #nosec G304 -- same path as Load
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("reading config for migration check: %w", err)
+	}
+
+	var raw struct {
+		ConfigVersion int `json:"config_version"`
+	}
+	_ = json.Unmarshal(data, &raw) // on malformed JSON raw.ConfigVersion stays 0
+
+	if raw.ConfigVersion >= CurrentConfigVersion {
+		return "", nil
+	}
+
+	backupPath, err := BackupConfigFile(path)
+	if err != nil {
+		return "", fmt.Errorf("backing up config before migration persist: %w", err)
+	}
+	if err := saveToFile(cfg, path); err != nil {
+		return backupPath, fmt.Errorf("writing migrated config: %w", err)
+	}
+	return backupPath, nil
+}

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -1,0 +1,248 @@
+package config_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"sqmeter-alpaca-safetymonitor/internal/config"
+)
+
+// ---------- Load: version rejection ------------------------------------------
+
+// TestLoad_FutureVersionFails verifies that a config_version newer than the
+// binary supports produces a clear error rather than silently loading.
+func TestLoad_FutureVersionFails(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	futureVersion := config.CurrentConfigVersion + 1
+	content := []byte(`{"SQMETER_BASE_URL":"http://test.local","config_version":` +
+		string(rune('0'+futureVersion)) + `}`)
+	if err := os.WriteFile(path, content, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := config.Load(path)
+	if err == nil {
+		t.Fatal("expected error for future config_version, got nil")
+	}
+	if !strings.Contains(err.Error(), "newer than this binary supports") {
+		t.Errorf("error message should mention 'newer than this binary supports', got: %v", err)
+	}
+}
+
+// TestLoad_CurrentVersionLoadsOK confirms the current version loads without error.
+func TestLoad_CurrentVersionLoadsOK(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := config.SaveDefault(path); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("current version should load without error: %v", err)
+	}
+	if cfg.ConfigVersion != config.CurrentConfigVersion {
+		t.Errorf("ConfigVersion: want %d, got %d", config.CurrentConfigVersion, cfg.ConfigVersion)
+	}
+}
+
+// ---------- BackupConfigFile -------------------------------------------------
+
+// TestBackupConfigFile verifies that a timestamped backup is created beside the
+// original file with .bak extension and identical content.
+func TestBackupConfigFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	original := []byte(`{"SQMETER_BASE_URL":"http://original.local"}`)
+	if err := os.WriteFile(path, original, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	backupPath, err := config.BackupConfigFile(path)
+	if err != nil {
+		t.Fatalf("BackupConfigFile: %v", err)
+	}
+	if backupPath == "" {
+		t.Fatal("expected non-empty backup path")
+	}
+	if !strings.HasSuffix(backupPath, ".bak") {
+		t.Errorf("backup path should end in .bak, got %q", backupPath)
+	}
+	if filepath.Dir(backupPath) != dir {
+		t.Errorf("backup should be in same directory as original: want %q, got %q", dir, filepath.Dir(backupPath))
+	}
+
+	got, err := os.ReadFile(backupPath)
+	if err != nil {
+		t.Fatalf("reading backup: %v", err)
+	}
+	if string(got) != string(original) {
+		t.Errorf("backup content mismatch: want %q, got %q", original, got)
+	}
+}
+
+// TestBackupConfigFile_MissingSourceFails verifies that backing up a
+// non-existent file returns an error (not a silent no-op).
+func TestBackupConfigFile_MissingSourceFails(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nonexistent.json")
+	_, err := config.BackupConfigFile(path)
+	if err == nil {
+		t.Fatal("expected error when source file does not exist")
+	}
+}
+
+// ---------- PersistMigrationIfNeeded -----------------------------------------
+
+// TestPersistMigrationIfNeeded_OldVersionBacksUpAndWrites verifies that when
+// the on-disk config has an old version, PersistMigrationIfNeeded creates a
+// backup and rewrites the file with the migrated (current-version) config.
+func TestPersistMigrationIfNeeded_OldVersionBacksUpAndWrites(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	// Write a v0 config (no config_version field).
+	old := `{"SQMETER_BASE_URL":"http://old.local","ALPACA_HTTP_PORT":11111}`
+	if err := os.WriteFile(path, []byte(old), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	backupPath, err := config.PersistMigrationIfNeeded(path, cfg)
+	if err != nil {
+		t.Fatalf("PersistMigrationIfNeeded: %v", err)
+	}
+	if backupPath == "" {
+		t.Fatal("expected a backup path to be returned")
+	}
+
+	// Backup must contain the original content.
+	backupData, err := os.ReadFile(backupPath)
+	if err != nil {
+		t.Fatalf("reading backup: %v", err)
+	}
+	if !strings.Contains(string(backupData), "http://old.local") {
+		t.Errorf("backup should preserve original URL, got: %s", backupData)
+	}
+
+	// Migrated file must be valid JSON with the current version.
+	migratedData, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading migrated config: %v", err)
+	}
+	var migrated config.Config
+	if err := json.Unmarshal(migratedData, &migrated); err != nil {
+		t.Fatalf("migrated config is not valid JSON: %v", err)
+	}
+	if migrated.ConfigVersion != config.CurrentConfigVersion {
+		t.Errorf("migrated config_version: want %d, got %d", config.CurrentConfigVersion, migrated.ConfigVersion)
+	}
+	if migrated.SQMeterBaseURL != "http://old.local" {
+		t.Errorf("SQMeterBaseURL not preserved after migration: got %q", migrated.SQMeterBaseURL)
+	}
+}
+
+// TestPersistMigrationIfNeeded_AlreadyCurrent_NoBackup verifies that a config
+// already at the current version is not backed up or rewritten.
+func TestPersistMigrationIfNeeded_AlreadyCurrent_NoBackup(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := config.SaveDefault(path); err != nil {
+		t.Fatal(err)
+	}
+
+	modTimeBefore, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	backupPath, err := config.PersistMigrationIfNeeded(path, cfg)
+	if err != nil {
+		t.Fatalf("PersistMigrationIfNeeded: %v", err)
+	}
+	if backupPath != "" {
+		t.Errorf("expected no backup for current-version config, got %q", backupPath)
+	}
+
+	modTimeAfter, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !modTimeAfter.ModTime().Equal(modTimeBefore.ModTime()) {
+		t.Error("config file should not be rewritten when already at current version")
+	}
+}
+
+// TestPersistMigrationIfNeeded_EmptyPath_NoOp verifies that an empty path
+// is a safe no-op.
+func TestPersistMigrationIfNeeded_EmptyPath_NoOp(t *testing.T) {
+	cfg := config.Defaults()
+	backupPath, err := config.PersistMigrationIfNeeded("", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if backupPath != "" {
+		t.Errorf("expected empty backup path for empty config path, got %q", backupPath)
+	}
+}
+
+// TestPersistMigrationIfNeeded_MissingFile_NoOp verifies that a missing config
+// file is treated as a no-op (not an error).
+func TestPersistMigrationIfNeeded_MissingFile_NoOp(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nonexistent.json")
+	cfg := config.Defaults()
+	backupPath, err := config.PersistMigrationIfNeeded(path, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error for missing file: %v", err)
+	}
+	if backupPath != "" {
+		t.Errorf("expected empty backup path when file does not exist, got %q", backupPath)
+	}
+}
+
+// TestPersistMigrationIfNeeded_WritesValidJSON verifies that the migrated file
+// round-trips through JSON without data loss.
+func TestPersistMigrationIfNeeded_WritesValidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	old := `{"SQMETER_BASE_URL":"http://roundtrip.local","ALPACA_HTTP_PORT":22222,"FAIL_CLOSED":false}`
+	if err := os.WriteFile(path, []byte(old), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if _, err := config.PersistMigrationIfNeeded(path, cfg); err != nil {
+		t.Fatalf("PersistMigrationIfNeeded: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading migrated config: %v", err)
+	}
+	var out config.Config
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("migrated file is not valid JSON: %v", err)
+	}
+	if out.AlpacaHTTPPort != 22222 {
+		t.Errorf("AlpacaHTTPPort not preserved: want 22222, got %d", out.AlpacaHTTPPort)
+	}
+	if out.FailClosed {
+		t.Error("FailClosed should be false after migration round-trip")
+	}
+}

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+const (
+	// AppDataDirName is the subdirectory name used under %ProgramData% on Windows.
+	AppDataDirName = "SQMeter SafetyMonitor"
+
+	// ReleasesURL is the canonical URL for checking the latest release.
+	ReleasesURL = "https://github.com/DeanJ87/SQMeter-Safety-Monitor/releases"
+)
+
+// DefaultConfigPath returns the platform-appropriate default path for config.json.
+//
+// On Windows:  %ProgramData%\SQMeter SafetyMonitor\config.json
+// Other:       <exeDir>/config.json  (preserves prior behaviour)
+//
+// The --config CLI flag always overrides this value.
+func DefaultConfigPath(exeDir string) string {
+	if runtime.GOOS == "windows" {
+		if pd := os.Getenv("ProgramData"); pd != "" {
+			return filepath.Join(pd, AppDataDirName, "config.json")
+		}
+		// ProgramData is always set on modern Windows; fall back to exe dir.
+	}
+	return filepath.Join(exeDir, "config.json")
+}
+
+// DefaultUUIDPath returns the platform-appropriate default path for device-uuid.txt.
+//
+// On Windows:  %ProgramData%\SQMeter SafetyMonitor\device-uuid.txt
+// Other:       <exeDir>/device-uuid.txt
+func DefaultUUIDPath(exeDir string) string {
+	if runtime.GOOS == "windows" {
+		if pd := os.Getenv("ProgramData"); pd != "" {
+			return filepath.Join(pd, AppDataDirName, "device-uuid.txt")
+		}
+	}
+	return filepath.Join(exeDir, "device-uuid.txt")
+}

--- a/internal/config/paths_test.go
+++ b/internal/config/paths_test.go
@@ -1,0 +1,120 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"sqmeter-alpaca-safetymonitor/internal/config"
+)
+
+// TestDefaultConfigPath_NonWindows verifies that on non-Windows platforms the
+// default config path is beside the executable directory.
+func TestDefaultConfigPath_NonWindows(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("non-Windows path test skipped on Windows")
+	}
+	exeDir := "/opt/sqmeter"
+	got := config.DefaultConfigPath(exeDir)
+	want := filepath.Join(exeDir, "config.json")
+	if got != want {
+		t.Errorf("DefaultConfigPath(%q) = %q, want %q", exeDir, got, want)
+	}
+}
+
+// TestDefaultUUIDPath_NonWindows verifies that on non-Windows the UUID file
+// defaults to the executable directory.
+func TestDefaultUUIDPath_NonWindows(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("non-Windows path test skipped on Windows")
+	}
+	exeDir := "/opt/sqmeter"
+	got := config.DefaultUUIDPath(exeDir)
+	want := filepath.Join(exeDir, "device-uuid.txt")
+	if got != want {
+		t.Errorf("DefaultUUIDPath(%q) = %q, want %q", exeDir, got, want)
+	}
+}
+
+// TestDefaultConfigPath_Windows_ProgramData verifies the Windows ProgramData
+// path by injecting the env var (cross-platform test).
+func TestDefaultConfigPath_Windows_ProgramData(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows ProgramData path test only runs on Windows")
+	}
+	pd := os.Getenv("ProgramData")
+	if pd == "" {
+		t.Skip("ProgramData not set")
+	}
+	got := config.DefaultConfigPath("/any/exe/dir")
+	want := filepath.Join(pd, config.AppDataDirName, "config.json")
+	if got != want {
+		t.Errorf("DefaultConfigPath on Windows = %q, want %q", got, want)
+	}
+}
+
+// TestDefaultUUIDPath_Windows_ProgramData verifies the Windows ProgramData
+// UUID path.
+func TestDefaultUUIDPath_Windows_ProgramData(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows ProgramData path test only runs on Windows")
+	}
+	pd := os.Getenv("ProgramData")
+	if pd == "" {
+		t.Skip("ProgramData not set")
+	}
+	got := config.DefaultUUIDPath("/any/exe/dir")
+	want := filepath.Join(pd, config.AppDataDirName, "device-uuid.txt")
+	if got != want {
+		t.Errorf("DefaultUUIDPath on Windows = %q, want %q", got, want)
+	}
+}
+
+// TestSaveDefault_CreatesParentDirs verifies that SaveDefault creates any
+// missing parent directories (required for the ProgramData path on first install).
+func TestSaveDefault_CreatesParentDirs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "subdir", "config.json")
+
+	if err := config.SaveDefault(path); err != nil {
+		t.Fatalf("SaveDefault with deep path: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("config file not created: %v", err)
+	}
+}
+
+// TestHolderUpdate_CreatesParentDirs verifies that Holder.Update creates any
+// missing parent directories before writing, so the app can safely write to
+// a ProgramData path that was not pre-created.
+func TestHolderUpdate_CreatesParentDirs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "deep", "dir", "config.json")
+
+	h := config.NewHolder(config.Defaults(), path)
+	updated := *h.Get()
+	updated.LogLevel = "debug"
+	if err := h.Update(&updated); err != nil {
+		t.Fatalf("Update with deep path: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("config file not created by Update: %v", err)
+	}
+	if !strings.Contains(string(data), "debug") {
+		t.Errorf("expected 'debug' in persisted config, got: %s", data)
+	}
+}
+
+// TestReleasesURL verifies the releases URL constant is set and looks reasonable.
+func TestReleasesURL(t *testing.T) {
+	url := config.ReleasesURL
+	if url == "" {
+		t.Fatal("ReleasesURL must not be empty")
+	}
+	if !strings.HasPrefix(url, "https://github.com/") {
+		t.Errorf("ReleasesURL should be a GitHub URL, got %q", url)
+	}
+}


### PR DESCRIPTION
## Summary

- Documents the supported install-over-existing upgrade flow in README (new Upgrading section).
- Adds an Inno Setup `[Code]` `BeforeInstall` hook that stops and unregisters the running service before replacing the binary, fixing the locked-exe problem on upgrade. Fresh installs are unaffected (stop/uninstall fail silently when no prior binary exists).
- Clarifies service stop/start, config preservation, rollback, and that automatic updating is not implemented.
- Adds `config_version` / `CurrentConfigVersion = 1` scaffolding to `Config`. Old configs without the field load as 0 and are silently normalised to the current version by `Load`. No migration logic needed yet.

## Changes

| File | What changed |
|------|-------------|
| `installer/setup.iss` | Added `[Code]` `StopExistingService` proc + `BeforeInstall` on the binary file entry; added explanatory comments throughout |
| `README.md` | New **Upgrading** section: install-over-existing steps, stop/replace/restart table, rollback, automatic-update non-status |
| `internal/config/config.go` | `ConfigVersion int` field, `CurrentConfigVersion = 1` constant, `Load` stamps current version on old files |
| `internal/config/config_test.go` | Three new tests: old config without `config_version` loads, `Defaults()` returns current version, `SaveDefault` writes versioned file |

## Validation

- `go test ./internal/config` — 31 tests, all pass
- `go test ./...` — all packages pass with `-race`
- `gofmt -l ./internal/config/` — clean
- Installer script reviewed manually; Inno Setup build validation is CI/Windows-only

## Deferred follow-up

- Phase 2: real config migration logic (increment `CurrentConfigVersion`, apply field renames/defaults on load, back up old file before rewriting)
- Phase 3: move config/logs to `%ProgramData%` if appropriate
- Phase 4: tray "check for updates" linking to GitHub Releases

Refs #31