### PR TITLE
Add web-based service controls for restart and shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,32 @@ and how to troubleshoot conflicts with ASCOM Alpaca Simulators, see
 
 ---
 
+## Web-based service controls
+
+The dashboard at `http://localhost:11111/` includes **Restart service** and
+**Stop service** buttons once the service is running. Both actions require a
+browser confirmation before executing.
+
+- **Restart** — the process exits with code 1. If the service manager is
+  configured to restart on failure (Windows Service recovery options, NSSM
+  `AppExit` policy, or `systemd Restart=on-failure`), the process restarts
+  automatically. If no restart policy is configured the process simply exits.
+- **Stop** — the process exits cleanly (code 0) and stays stopped until
+  manually restarted. N.I.N.A. and all Alpaca clients lose safety integration
+  while the service is stopped.
+
+Both controls use `POST` requests; plain navigation links (`GET`) cannot
+trigger them. If the service is bound to a non-loopback address
+(`ALPACA_HTTP_BIND=0.0.0.0`) the dashboard displays a network-reachability
+warning next to the controls.
+
+> **Note:** True automatic restart after a web-triggered restart is only
+> guaranteed when the service manager is explicitly configured for it. The
+> service itself cannot restart its own process; it signals intent through the
+> exit code.
+
+---
+
 ## Running as a Windows service
 
 ### Option A: NSSM (recommended)

--- a/cmd/sqmeter-alpaca-safetymonitor/main.go
+++ b/cmd/sqmeter-alpaca-safetymonitor/main.go
@@ -16,6 +16,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -41,8 +42,10 @@ type program struct {
 	cfgPath  string
 	uuidPath string
 
-	cancel  context.CancelFunc
-	stopped chan struct{}
+	cancel           context.CancelFunc
+	stopped          chan struct{}
+	svc              service.Service
+	restartRequested atomic.Bool
 }
 
 func (p *program) Start(s service.Service) error {
@@ -123,6 +126,16 @@ func (p *program) run(ctx context.Context, interactive bool) {
 		logger.Error("failed to initialise web handler", "error", err)
 		return
 	}
+
+	webHandler.WithServiceControl(
+		func() {
+			p.restartRequested.Store(true)
+			p.svc.Stop() //nolint:errcheck
+		},
+		func() {
+			p.svc.Stop() //nolint:errcheck
+		},
+	)
 
 	alpacaHandler := alpaca.New(cfgHolder, stateHolder, deviceUUID, version, pol.PollNow)
 
@@ -278,6 +291,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+	prg.svc = s
 
 	if *svcCmd != "" {
 		if err := service.Control(s, *svcCmd); err != nil {
@@ -302,6 +316,14 @@ func main() {
 
 	if err := s.Run(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	// Exit with code 1 when a web-triggered restart was requested so that a
+	// service manager configured for "restart on failure" (Windows Service
+	// recovery options, NSSM AppExit, systemd Restart=on-failure) will restart
+	// the process. A plain stop exits with 0 and the service stays stopped.
+	if prg.restartRequested.Load() {
 		os.Exit(1)
 	}
 }

--- a/cmd/sqmeter-alpaca-safetymonitor/main.go
+++ b/cmd/sqmeter-alpaca-safetymonitor/main.go
@@ -130,10 +130,10 @@ func (p *program) run(ctx context.Context, interactive bool) {
 	webHandler.WithServiceControl(
 		func() {
 			p.restartRequested.Store(true)
-			p.svc.Stop() //nolint:errcheck
+			_ = p.svc.Stop() /* #nosec G104 -- shutdown call triggered by web endpoint; error cannot be acted on in this goroutine */ //nolint:errcheck
 		},
 		func() {
-			p.svc.Stop() //nolint:errcheck
+			_ = p.svc.Stop() /* #nosec G104 -- shutdown call triggered by web endpoint; error cannot be acted on in this goroutine */ //nolint:errcheck
 		},
 	)
 

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -26,6 +26,17 @@ type Handler struct {
 	startT          time.Time
 	discoveryStatus func() discovery.Status
 	version         string
+	onRestart       func()
+	onStop          func()
+}
+
+// WithServiceControl registers callbacks for web-triggered restart and stop.
+// restart is called to request a graceful exit that the service manager should
+// restart (exit code 1); stop is called for a clean shutdown (exit code 0).
+// Either or both may be nil; missing callbacks return HTTP 501.
+func (h *Handler) WithServiceControl(restart, stop func()) {
+	h.onRestart = restart
+	h.onStop = stop
 }
 
 // WithDiscovery registers a discovery status getter so the handler can expose
@@ -70,27 +81,30 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("PUT /config.json", h.PutConfigJSON)
 	mux.HandleFunc("POST /api/test-sqmeter", h.TestSQMeter)
 	mux.HandleFunc("GET /api/diagnostics", h.Diagnostics)
+	mux.HandleFunc("POST /api/service/restart", h.ServiceRestart)
+	mux.HandleFunc("POST /api/service/stop", h.ServiceStop)
 }
 
 // ---------- dashboard --------------------------------------------------------
 
 type DashboardData struct {
-	SQMeterURL        string
-	HTTPPort          int
-	DiscoveryPort     int
-	Uptime            string
-	State             state.EvaluatedState
-	Connected         bool
-	Override          string
-	LastPoll          string
-	LastSuccess       string
-	HasData           bool
-	DewMargin         float64
-	WideOpen          bool
-	DiscoveryRunning  bool
-	DiscoveryHealthy  bool
-	DiscoveryError    string
-	DiscoveryHasStats bool // true when we have a status getter
+	SQMeterURL            string
+	HTTPPort              int
+	DiscoveryPort         int
+	Uptime                string
+	State                 state.EvaluatedState
+	Connected             bool
+	Override              string
+	LastPoll              string
+	LastSuccess           string
+	HasData               bool
+	DewMargin             float64
+	WideOpen              bool
+	DiscoveryRunning      bool
+	DiscoveryHealthy      bool
+	DiscoveryError        string
+	DiscoveryHasStats     bool // true when we have a status getter
+	ServiceControlEnabled bool // true when restart/stop callbacks are wired
 }
 
 func (h *Handler) Dashboard(w http.ResponseWriter, r *http.Request) {
@@ -127,6 +141,7 @@ func (h *Handler) Dashboard(w http.ResponseWriter, r *http.Request) {
 		data.DiscoveryHealthy = ds.Healthy
 		data.DiscoveryError = ds.LastError
 	}
+	data.ServiceControlEnabled = h.onRestart != nil || h.onStop != nil
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := h.dash.Execute(w, data); err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
@@ -449,6 +464,66 @@ func (h *Handler) Diagnostics(w http.ResponseWriter, r *http.Request) {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	_ = enc.Encode(report)
+}
+
+// ---------- service controls -------------------------------------------------
+
+type serviceControlResponse struct {
+	OK      bool   `json:"ok"`
+	Message string `json:"message"`
+}
+
+// ServiceRestart handles POST /api/service/restart.
+// It responds with JSON and then, after flushing the response, calls the
+// registered restart callback. The process exits with code 1 so that a
+// service manager configured for "restart on failure" (e.g. Windows Service
+// recovery options or NSSM) will restart it automatically. If no service
+// manager restart policy is configured the process simply exits.
+func (h *Handler) ServiceRestart(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	enc := json.NewEncoder(w)
+	if h.onRestart == nil {
+		w.WriteHeader(http.StatusNotImplemented)
+		enc.Encode(serviceControlResponse{OK: false, Message: "restart not available"}) //nolint:errcheck
+		return
+	}
+	enc.Encode(serviceControlResponse{ //nolint:errcheck
+		OK:      true,
+		Message: "restart initiated; service will exit — restart depends on service manager configuration",
+	})
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		h.onRestart()
+	}()
+}
+
+// ServiceStop handles POST /api/service/stop.
+// It responds with JSON and then calls the registered stop callback after
+// flushing the response. The process exits cleanly (code 0); the service will
+// remain stopped until manually restarted. N.I.N.A. and other Alpaca clients
+// will lose safety integration until the service is running again.
+func (h *Handler) ServiceStop(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	enc := json.NewEncoder(w)
+	if h.onStop == nil {
+		w.WriteHeader(http.StatusNotImplemented)
+		enc.Encode(serviceControlResponse{OK: false, Message: "stop not available"}) //nolint:errcheck
+		return
+	}
+	enc.Encode(serviceControlResponse{ //nolint:errcheck
+		OK:      true,
+		Message: "stop initiated; N.I.N.A./Alpaca safety integration will be unavailable until the service is restarted",
+	})
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		h.onStop()
+	}()
 }
 
 // ---------- SQMeter connection test -----------------------------------------

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -484,10 +484,10 @@ func (h *Handler) ServiceRestart(w http.ResponseWriter, r *http.Request) {
 	enc := json.NewEncoder(w)
 	if h.onRestart == nil {
 		w.WriteHeader(http.StatusNotImplemented)
-		enc.Encode(serviceControlResponse{OK: false, Message: "restart not available"}) //nolint:errcheck
+		_ = enc.Encode(serviceControlResponse{OK: false, Message: "restart not available"}) /* #nosec G104 -- writing JSON to http.ResponseWriter; error indicates broken connection, nothing to act on */ //nolint:errcheck
 		return
 	}
-	enc.Encode(serviceControlResponse{ //nolint:errcheck
+	_ = enc.Encode(serviceControlResponse{ /* #nosec G104 -- same as above */ //nolint:errcheck
 		OK:      true,
 		Message: "restart initiated; service will exit — restart depends on service manager configuration",
 	})
@@ -510,10 +510,10 @@ func (h *Handler) ServiceStop(w http.ResponseWriter, r *http.Request) {
 	enc := json.NewEncoder(w)
 	if h.onStop == nil {
 		w.WriteHeader(http.StatusNotImplemented)
-		enc.Encode(serviceControlResponse{OK: false, Message: "stop not available"}) //nolint:errcheck
+		_ = enc.Encode(serviceControlResponse{OK: false, Message: "stop not available"}) /* #nosec G104 -- writing JSON to http.ResponseWriter; error indicates broken connection, nothing to act on */ //nolint:errcheck
 		return
 	}
-	enc.Encode(serviceControlResponse{ //nolint:errcheck
+	_ = enc.Encode(serviceControlResponse{ /* #nosec G104 -- same as above */ //nolint:errcheck
 		OK:      true,
 		Message: "stop initiated; N.I.N.A./Alpaca safety integration will be unavailable until the service is restarted",
 	})

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -796,6 +796,162 @@ func TestPostSetup_InvalidOptionalFloat_Ignores(t *testing.T) {
 	}
 }
 
+// ---------- POST /api/service/restart & /api/service/stop -------------------
+
+func TestServiceRestart_WithCallback_Returns200(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	called := make(chan struct{}, 1)
+	h.WithServiceControl(func() { called <- struct{}{} }, nil)
+
+	w := serve(t, h, http.MethodPost, "/api/service/restart", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST /api/service/restart: want 200, got %d — body: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		OK      bool   `json:"ok"`
+		Message string `json:"message"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("POST /api/service/restart: invalid JSON: %v", err)
+	}
+	if !resp.OK {
+		t.Errorf("POST /api/service/restart: want ok=true, got false; message: %s", resp.Message)
+	}
+	if resp.Message == "" {
+		t.Error("POST /api/service/restart: want non-empty message")
+	}
+}
+
+func TestServiceStop_WithCallback_Returns200(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	called := make(chan struct{}, 1)
+	h.WithServiceControl(nil, func() { called <- struct{}{} })
+
+	w := serve(t, h, http.MethodPost, "/api/service/stop", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("POST /api/service/stop: want 200, got %d — body: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		OK      bool   `json:"ok"`
+		Message string `json:"message"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("POST /api/service/stop: invalid JSON: %v", err)
+	}
+	if !resp.OK {
+		t.Errorf("POST /api/service/stop: want ok=true, got false; message: %s", resp.Message)
+	}
+	if resp.Message == "" {
+		t.Error("POST /api/service/stop: want non-empty message")
+	}
+}
+
+func TestServiceRestart_WithoutCallback_Returns501(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	// no WithServiceControl call
+
+	w := serve(t, h, http.MethodPost, "/api/service/restart", "")
+	if w.Code != http.StatusNotImplemented {
+		t.Errorf("POST /api/service/restart without callback: want 501, got %d", w.Code)
+	}
+	var resp struct {
+		OK bool `json:"ok"`
+	}
+	json.NewDecoder(w.Body).Decode(&resp) //nolint:errcheck
+	if resp.OK {
+		t.Error("POST /api/service/restart without callback: want ok=false")
+	}
+}
+
+func TestServiceStop_WithoutCallback_Returns501(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	// no WithServiceControl call
+
+	w := serve(t, h, http.MethodPost, "/api/service/stop", "")
+	if w.Code != http.StatusNotImplemented {
+		t.Errorf("POST /api/service/stop without callback: want 501, got %d", w.Code)
+	}
+	var resp struct {
+		OK bool `json:"ok"`
+	}
+	json.NewDecoder(w.Body).Decode(&resp) //nolint:errcheck
+	if resp.OK {
+		t.Error("POST /api/service/stop without callback: want ok=false")
+	}
+}
+
+func TestServiceRestart_GET_DoesNotTriggerAction(t *testing.T) {
+	// GET /api/service/restart falls through to the Dashboard catch-all ("GET /")
+	// and never calls the service callback. This is the intended safety behaviour:
+	// service actions require an explicit POST.
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	triggered := false
+	h.WithServiceControl(func() { triggered = true }, nil)
+
+	w := serve(t, h, http.MethodGet, "/api/service/restart", "")
+	if w.Code != http.StatusOK {
+		t.Errorf("GET /api/service/restart: want 200 (dashboard fallback), got %d", w.Code)
+	}
+	if triggered {
+		t.Error("GET /api/service/restart: must not trigger restart callback")
+	}
+	// Must not return service-control JSON
+	if strings.Contains(w.Body.String(), `"ok"`) {
+		t.Error("GET /api/service/restart: must not return service-control JSON")
+	}
+}
+
+func TestServiceStop_GET_DoesNotTriggerAction(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	triggered := false
+	h.WithServiceControl(nil, func() { triggered = true })
+
+	w := serve(t, h, http.MethodGet, "/api/service/stop", "")
+	if w.Code != http.StatusOK {
+		t.Errorf("GET /api/service/stop: want 200 (dashboard fallback), got %d", w.Code)
+	}
+	if triggered {
+		t.Error("GET /api/service/stop: must not trigger stop callback")
+	}
+	if strings.Contains(w.Body.String(), `"ok"`) {
+		t.Error("GET /api/service/stop: must not return service-control JSON")
+	}
+}
+
+func TestDashboard_ServiceControlsVisible_WhenWired(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	h.WithServiceControl(func() {}, func() {})
+
+	w := serve(t, h, http.MethodGet, "/", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("dashboard: want 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "service-controls") {
+		t.Error("dashboard: expected service-controls section when callbacks wired")
+	}
+	if !strings.Contains(body, "Restart service") {
+		t.Error("dashboard: expected 'Restart service' button")
+	}
+	if !strings.Contains(body, "Stop service") {
+		t.Error("dashboard: expected 'Stop service' button")
+	}
+}
+
+func TestDashboard_ServiceControlsHidden_WhenNotWired(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	// no WithServiceControl
+
+	w := serve(t, h, http.MethodGet, "/", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("dashboard: want 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if strings.Contains(body, "service-controls") {
+		t.Error("dashboard: service-controls section should be absent when not wired")
+	}
+}
+
 func TestGetSetup_DisplaysOptionalFloats(t *testing.T) {
 	h, cfgHolder, _ := newTestWebHandler(t, true, safeEv())
 

--- a/internal/web/templates/dashboard.html
+++ b/internal/web/templates/dashboard.html
@@ -119,6 +119,22 @@
   .links a { color: #5b9bd5; text-decoration: none; margin-right: 12px; }
   .links a:hover { text-decoration: underline; }
 
+  .svc-controls { display: flex; gap: 8px; margin-top: 10px; flex-wrap: wrap; }
+  .btn {
+    padding: 6px 14px;
+    border: none;
+    border-radius: 5px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+    letter-spacing: 0.4px;
+  }
+  .btn-warn   { background: #7a4a00; color: #f39c12; border: 1px solid #f39c12; }
+  .btn-warn:hover   { background: #9a5e00; }
+  .btn-danger { background: #5a0a0a; color: #e74c3c; border: 1px solid #e74c3c; }
+  .btn-danger:hover { background: #7a1010; }
+  #svc-msg { margin-top: 8px; font-size: 0.8rem; display: none; }
+
   footer {
     margin-top: 20px;
     border-top: 1px solid var(--border);
@@ -264,6 +280,49 @@
   </div>
 
 </div>
+
+{{if .ServiceControlEnabled}}
+<div class="card" style="margin-bottom:16px;" id="service-controls">
+  <h2>Service Controls</h2>
+  {{if .WideOpen}}
+  <p style="color:var(--warn-fg);font-size:0.8rem;margin-bottom:6px;">
+    ⚠ Service is reachable from the network — these controls affect all connected clients.
+  </p>
+  {{end}}
+  <p style="color:var(--muted);font-size:0.8rem;margin-bottom:2px;">
+    Restart exits and relies on the service manager to restart automatically.<br>
+    Stop ends the process — N.I.N.A./Alpaca integration is unavailable until the service is restarted.
+  </p>
+  <div class="svc-controls">
+    <button class="btn btn-warn" onclick="svcAction('restart')">Restart service</button>
+    <button class="btn btn-danger" onclick="svcAction('stop')">Stop service</button>
+  </div>
+  <div id="svc-msg"></div>
+</div>
+<script>
+function svcAction(action) {
+  var msgs = {
+    restart: 'Restart the service?\n\nThe service will exit and restart if the service manager is configured to do so (Windows Service recovery, NSSM, or systemd Restart=on-failure). It will briefly be unavailable.',
+    stop:    'Stop the service?\n\nWARNING: This will shut down the safety bridge. N.I.N.A. and all Alpaca clients will lose safety integration until the service is manually restarted.\n\nAre you sure?'
+  };
+  if (!window.confirm(msgs[action])) return;
+  var msg = document.getElementById('svc-msg');
+  msg.textContent = 'Sending ' + action + ' request…';
+  msg.style.display = 'block';
+  msg.style.color = '#8892a4';
+  fetch('/api/service/' + action, {method: 'POST'})
+    .then(function(r) { return r.json(); })
+    .then(function(d) {
+      msg.textContent = d.message || (d.ok ? 'Done.' : 'Failed.');
+      msg.style.color = d.ok ? '#2ecc71' : '#e74c3c';
+    })
+    .catch(function() {
+      msg.textContent = action + ' command sent — service is shutting down.';
+      msg.style.color = '#f39c12';
+    });
+}
+</script>
+{{end}}
 
 <div class="links">
   Alpaca:


### PR DESCRIPTION
## Summary

- Adds `POST /api/service/restart` and `POST /api/service/stop` endpoints wired into the process lifecycle.
- Restart exits with code 1 so service managers configured for restart-on-failure (Windows Service recovery options, NSSM `AppExit` policy, systemd `Restart=on-failure`) restart the process automatically; stop exits cleanly with code 0 and stays stopped.
- Dashboard gains Restart and Stop buttons with JavaScript confirmation dialogs, a network-reachability warning when bound to a non-loopback address, and a plain-language note that stopping disables N.I.N.A./Alpaca safety integration until the service is restarted.
- `GET` requests to the control paths fall through to the Dashboard catch-all and never trigger service actions — no plain link can accidentally trigger a stop or restart.
- README documents the web controls, restart semantics, and the honest caveat that automatic restart depends on service manager configuration.

## Validation

- `go test ./internal/web`
- `go test ./...`
- `go vet ./...`

Closes #20