### PR TITLE
Implement ASCOM Alpaca ObservingConditions support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/DeanJ87/SQMeter-Safety-Monitor/actions/workflows/ci.yml/badge.svg)](https://github.com/DeanJ87/SQMeter-Safety-Monitor/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/github/DeanJ87/SQMeter-Safety-Monitor/graph/badge.svg?token=I7DHSX92BN)](https://codecov.io/github/DeanJ87/SQMeter-Safety-Monitor)
 
-A standalone **ASCOM Alpaca SafetyMonitor** bridge for the [SQMeter ESP32](https://deanj87.github.io/SQMeter/) sky-quality sensor.
+A standalone **ASCOM Alpaca SafetyMonitor and ObservingConditions** bridge for the [SQMeter ESP32](https://deanj87.github.io/SQMeter/) sky-quality sensor.
 
 Runs as a single `.exe` on your N.I.N.A. Windows machine.  No ASCOM COM drivers, no registration, no Visual Studio templates — pure Alpaca over HTTP/UDP.
 
@@ -16,13 +16,12 @@ Runs as a single `.exe` on your N.I.N.A. Windows machine.  No ASCOM COM drivers,
 - Polls `GET /api/sensors` on your SQMeter every few seconds
 - Evaluates configurable safety rules (cloud cover, SQM, humidity, dew-point margin, sensor health)
 - Exposes a standards-compliant **ASCOM Alpaca SafetyMonitor** device at `http://localhost:11111`
-- Responds to **ASCOM Alpaca UDP discovery** on port 32227 so N.I.N.A. finds it automatically
+- Exposes a standards-compliant **ASCOM Alpaca ObservingConditions** device at the same port
+- Responds to **ASCOM Alpaca UDP discovery** on port 32227 so N.I.N.A. finds both devices automatically
 - Serves a live **web dashboard** at `http://localhost:11111/`
 - Provides a `/status.json` debug endpoint
 
-It answers one question: **"Is it safe for the observatory to operate right now?"**
-
-> **Scope note:** This project is *only* the SafetyMonitor bridge.  An ObservingConditions driver (temperature, humidity, sky brightness, etc. as Alpaca properties) is a separate future project.
+It answers two questions: **"Is it safe for the observatory to operate right now?"** and **"What are the current sky conditions?"**
 
 ---
 
@@ -197,11 +196,25 @@ curl "http://localhost:11111/api/v1/safetymonitor/0/issafe?ClientID=1&ClientTran
 curl "http://localhost:11111/api/v1/safetymonitor/0/connected?ClientID=1&ClientTransactionID=2"
 curl "http://localhost:11111/api/v1/safetymonitor/0/name?ClientID=1&ClientTransactionID=3"
 
+# ObservingConditions
+curl "http://localhost:11111/api/v1/observingconditions/0/temperature?ClientID=1&ClientTransactionID=1"
+curl "http://localhost:11111/api/v1/observingconditions/0/humidity?ClientID=1&ClientTransactionID=2"
+curl "http://localhost:11111/api/v1/observingconditions/0/skyquality?ClientID=1&ClientTransactionID=3"
+curl "http://localhost:11111/api/v1/observingconditions/0/cloudcover?ClientID=1&ClientTransactionID=4"
+curl "http://localhost:11111/api/v1/observingconditions/0/dewpoint?ClientID=1&ClientTransactionID=5"
+curl "http://localhost:11111/api/v1/observingconditions/0/pressure?ClientID=1&ClientTransactionID=6"
+curl "http://localhost:11111/api/v1/observingconditions/0/skytemperature?ClientID=1&ClientTransactionID=7"
+curl "http://localhost:11111/api/v1/observingconditions/0/skybrightness?ClientID=1&ClientTransactionID=8"
+
+# Trigger an immediate sensor refresh (ObservingConditions)
+curl -X PUT http://localhost:11111/api/v1/observingconditions/0/refresh \
+     -d "ClientID=1&ClientTransactionID=20"
+
 # Status / health
 curl http://localhost:11111/status.json
 curl http://localhost:11111/health
 
-# Force refresh via Alpaca action
+# Force refresh via Alpaca action (SafetyMonitor)
 curl -X PUT http://localhost:11111/api/v1/safetymonitor/0/action \
      -d "Action=refresh&ClientID=1&ClientTransactionID=10"
 
@@ -214,6 +227,8 @@ curl -X PUT http://localhost:11111/api/v1/safetymonitor/0/connected \
 
 ## N.I.N.A. setup
 
+### SafetyMonitor
+
 1. Start `sqmeter-alpaca-safetymonitor.exe`
 2. Open N.I.N.A.
 3. Go to **Equipment → Safety Monitor**
@@ -222,11 +237,20 @@ curl -X PUT http://localhost:11111/api/v1/safetymonitor/0/connected \
 6. Select it and click **Connect**
 7. Watch the IsSafe indicator; verify it matches `http://localhost:11111/status.json`
 
+### ObservingConditions
+
+1. Go to **Equipment → Weather**
+2. In the device selector, choose **ASCOM Alpaca**
+3. Click **Refresh** — **SQMeter ObservingConditions** should appear alongside the SafetyMonitor
+4. Select it and click **Connect**
+
+Both devices are served from the same port and share the same SQMeter polling loop — no extra configuration required.
+
 If discovery does not work, manually add the device:
 
 - Host: `127.0.0.1`
 - Port: `11111`
-- Device type: `SafetyMonitor`
+- Device type: `SafetyMonitor` or `ObservingConditions`
 - Device number: `0`
 
 For a full explanation of how Alpaca discovery works, how to verify it manually,
@@ -312,13 +336,36 @@ git push origin v0.1.0
 
 ---
 
+## ObservingConditions properties
+
+| Property | Source | Notes |
+|---|---|---|
+| `cloudcover` | IR temperature differential | Requires IR sensor OK |
+| `dewpoint` | BME280 | Requires env sensor OK |
+| `humidity` | BME280 | Requires env sensor OK |
+| `pressure` | BME280 | Requires env sensor OK |
+| `skybrightness` | TSL2591 lux | Requires light sensor OK |
+| `skyquality` | TSL2591 SQM | Requires light sensor OK |
+| `skytemperature` | MLX90614 object temp | Requires IR sensor OK |
+| `temperature` | BME280 | Requires env sensor OK |
+| `rainrate` | — | Not implemented (no rain sensor) |
+| `starfwhm` | — | Not implemented |
+| `winddirection` | — | Not implemented (no anemometer) |
+| `windgust` | — | Not implemented |
+| `windspeed` | — | Not implemented |
+| `averageperiod` | — | Always 0; averaging not supported |
+
+When a sensor is temporarily unavailable (hardware error, stale data), the property returns an Alpaca error `0x04FF` with a descriptive message rather than a silently wrong value.
+
+---
+
 ## Alpaca Conform testing
 
 For ASCOM Conform Universal testing:
 
 1. Download [ASCOM Conform Universal](https://github.com/ASCOMInitiative/ConformU/releases)
 2. Configure it to connect to your Alpaca device at `http://127.0.0.1:11111` device `0`
-3. Run the SafetyMonitor conformance check
+3. Run the SafetyMonitor conformance check; repeat for ObservingConditions
 
 Target: `v1.0.0` once all Conform tests pass.
 

--- a/cmd/sqmeter-alpaca-safetymonitor/main.go
+++ b/cmd/sqmeter-alpaca-safetymonitor/main.go
@@ -38,8 +38,9 @@ var (
 // ---------- service wrapper --------------------------------------------------
 
 type program struct {
-	cfgPath  string
-	uuidPath string
+	cfgPath    string
+	uuidPath   string
+	ocUUIDPath string
 
 	cancel  context.CancelFunc
 	stopped chan struct{}
@@ -126,12 +127,21 @@ func (p *program) run(ctx context.Context, interactive bool) {
 
 	alpacaHandler := alpaca.New(cfgHolder, stateHolder, deviceUUID, version, pol.PollNow)
 
+	ocDeviceUUID, err := loadOrCreateUUID(p.ocUUIDPath)
+	if err != nil {
+		logger.Warn("could not persist OC device UUID, using ephemeral UUID", "error", err)
+	}
+	logger.Info("OC device UUID", "uuid", ocDeviceUUID)
+	ocHandler := alpaca.NewOC(cfgHolder, stateHolder, ocDeviceUUID, version, pol.PollNow)
+	alpacaHandler.AddConfiguredDevice(ocHandler.ConfiguredDevice())
+
 	disc := discovery.New(cfg.AlpacaDiscoveryPort, cfg.AlpacaHTTPPort, logger)
 	webHandler.WithDiscovery(disc.GetStatus)
 	webHandler.WithVersion(fmt.Sprintf("%s (commit %s, built %s)", version, commit, date))
 
 	mux := http.NewServeMux()
 	alpacaHandler.Register(mux)
+	ocHandler.Register(mux)
 	webHandler.Register(mux)
 
 	srv := &http.Server{
@@ -204,6 +214,7 @@ func main() {
 	var (
 		cfgPath            = flag.String("config", config.DefaultConfigPath(exeDir), "path to JSON config file")
 		uuidPath           = flag.String("uuid-file", config.DefaultUUIDPath(exeDir), "path to persist stable device UUID")
+		ocUUIDPath         = flag.String("oc-uuid-file", config.DefaultOCUUIDPath(exeDir), "path to persist stable ObservingConditions device UUID")
 		svcCmd             = flag.String("service", "", "manage the system service: install|uninstall|start|stop|status")
 		showVersion        = flag.Bool("version", false, "print version and exit")
 		writeDefaultConfig = flag.Bool("write-default-config", false, "write default config to --config path and exit")
@@ -263,8 +274,9 @@ func main() {
 	}
 
 	prg := &program{
-		cfgPath:  *cfgPath,
-		uuidPath: *uuidPath,
+		cfgPath:    *cfgPath,
+		uuidPath:   *uuidPath,
+		ocUUIDPath: *ocUUIDPath,
 	}
 
 	svcConfig := &service.Config{

--- a/internal/alpaca/handlers.go
+++ b/internal/alpaca/handlers.go
@@ -24,12 +24,19 @@ const (
 
 // Handler serves all ASCOM Alpaca endpoints for the SafetyMonitor device.
 type Handler struct {
-	cfgHolder  *config.Holder
-	holder     *state.Holder
-	serverTxID atomic.Uint32
-	deviceUUID string
-	version    string
-	refreshFn  func(ctx context.Context)
+	cfgHolder    *config.Holder
+	holder       *state.Holder
+	serverTxID   atomic.Uint32
+	deviceUUID   string
+	version      string
+	refreshFn    func(ctx context.Context)
+	extraDevices []ConfiguredDevice
+}
+
+// AddConfiguredDevice appends a device to the list returned by
+// /management/v1/configureddevices. Call this before the server starts.
+func (h *Handler) AddConfiguredDevice(dev ConfiguredDevice) {
+	h.extraDevices = append(h.extraDevices, dev)
 }
 
 // New creates a Handler.  refreshFn is called synchronously by the "refresh"
@@ -192,9 +199,11 @@ func (h *Handler) GetServerDescription(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) GetConfiguredDevices(w http.ResponseWriter, r *http.Request) {
 	_, clientTxID := parseGetParams(r)
-	writeJSON(w, okResp(clientTxID, h.nextTxID(), []ConfiguredDevice{
+	devices := []ConfiguredDevice{
 		{DeviceName: deviceName, DeviceType: deviceType, DeviceNumber: deviceNumber, UniqueID: h.deviceUUID},
-	}))
+	}
+	devices = append(devices, h.extraDevices...)
+	writeJSON(w, okResp(clientTxID, h.nextTxID(), devices))
 }
 
 // ---------- Common device GET endpoints --------------------------------------

--- a/internal/alpaca/observingconditions.go
+++ b/internal/alpaca/observingconditions.go
@@ -1,0 +1,404 @@
+package alpaca
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"sqmeter-alpaca-safetymonitor/internal/config"
+	"sqmeter-alpaca-safetymonitor/internal/state"
+)
+
+const (
+	ocInterfaceVersion = 1
+	ocDeviceName       = "SQMeter ObservingConditions"
+	ocDeviceType       = "ObservingConditions"
+	ocDeviceNumber     = 0
+	ocDescription      = "ASCOM Alpaca ObservingConditions bridge for SQMeter ESP32"
+	ocDriverInfo       = "SQMeter Alpaca ObservingConditions"
+)
+
+// OCHandler serves all ASCOM Alpaca endpoints for the ObservingConditions device.
+type OCHandler struct {
+	cfgHolder  *config.Holder
+	holder     *state.Holder
+	serverTxID atomic.Uint32
+	deviceUUID string
+	version    string
+	refreshFn  func(ctx context.Context)
+}
+
+// NewOC creates an OCHandler. refreshFn is called synchronously by the refresh
+// endpoint to perform an immediate SQMeter poll.
+func NewOC(cfgHolder *config.Holder, holder *state.Holder, deviceUUID, version string, refreshFn func(ctx context.Context)) *OCHandler {
+	return &OCHandler{
+		cfgHolder:  cfgHolder,
+		holder:     holder,
+		deviceUUID: deviceUUID,
+		version:    version,
+		refreshFn:  refreshFn,
+	}
+}
+
+// ConfiguredDevice returns the ConfiguredDevice descriptor for registration in
+// the management /configureddevices list.
+func (h *OCHandler) ConfiguredDevice() ConfiguredDevice {
+	return ConfiguredDevice{
+		DeviceName:   ocDeviceName,
+		DeviceType:   ocDeviceType,
+		DeviceNumber: ocDeviceNumber,
+		UniqueID:     h.deviceUUID,
+	}
+}
+
+// Register wires all ObservingConditions Alpaca routes onto mux.
+func (h *OCHandler) Register(mux *http.ServeMux) {
+	const base = "/api/v1/observingconditions/0/"
+
+	mux.HandleFunc("GET "+base+"connected", h.GetConnected)
+	mux.HandleFunc("GET "+base+"connecting", h.GetConnecting)
+	mux.HandleFunc("GET "+base+"description", h.GetDescription)
+	mux.HandleFunc("GET "+base+"driverinfo", h.GetDriverInfo)
+	mux.HandleFunc("GET "+base+"driverversion", h.GetDriverVersion)
+	mux.HandleFunc("GET "+base+"interfaceversion", h.GetInterfaceVersion)
+	mux.HandleFunc("GET "+base+"name", h.GetName)
+	mux.HandleFunc("GET "+base+"supportedactions", h.GetSupportedActions)
+	mux.HandleFunc("GET "+base+"devicestate", h.GetDeviceState)
+
+	mux.HandleFunc("PUT "+base+"connected", h.PutConnected)
+	mux.HandleFunc("PUT "+base+"connect", h.PutConnect)
+	mux.HandleFunc("PUT "+base+"disconnect", h.PutDisconnect)
+	mux.HandleFunc("PUT "+base+"action", h.PutAction)
+	mux.HandleFunc("PUT "+base+"commandblind", h.PutCommandNotImpl)
+	mux.HandleFunc("PUT "+base+"commandbool", h.PutCommandNotImpl)
+	mux.HandleFunc("PUT "+base+"commandstring", h.PutCommandNotImpl)
+
+	mux.HandleFunc("GET "+base+"averageperiod", h.GetAveragePeriod)
+	mux.HandleFunc("PUT "+base+"averageperiod", h.PutAveragePeriod)
+	mux.HandleFunc("GET "+base+"cloudcover", h.GetCloudCover)
+	mux.HandleFunc("GET "+base+"dewpoint", h.GetDewPoint)
+	mux.HandleFunc("GET "+base+"humidity", h.GetHumidity)
+	mux.HandleFunc("GET "+base+"pressure", h.GetPressure)
+	mux.HandleFunc("GET "+base+"rainrate", h.getNotImplementedFloat)
+	mux.HandleFunc("GET "+base+"skybrightness", h.GetSkyBrightness)
+	mux.HandleFunc("GET "+base+"skyquality", h.GetSkyQuality)
+	mux.HandleFunc("GET "+base+"skytemperature", h.GetSkyTemperature)
+	mux.HandleFunc("GET "+base+"starfwhm", h.getNotImplementedFloat)
+	mux.HandleFunc("GET "+base+"temperature", h.GetTemperature)
+	mux.HandleFunc("GET "+base+"winddirection", h.getNotImplementedFloat)
+	mux.HandleFunc("GET "+base+"windgust", h.getNotImplementedFloat)
+	mux.HandleFunc("GET "+base+"windspeed", h.getNotImplementedFloat)
+	mux.HandleFunc("GET "+base+"timesincemeasurement", h.GetTimeSinceMeasurement)
+	mux.HandleFunc("GET "+base+"sensordescription", h.GetSensorDescription)
+	mux.HandleFunc("PUT "+base+"refresh", h.PutRefresh)
+}
+
+func (h *OCHandler) nextTxID() uint32 { return h.serverTxID.Add(1) }
+
+// ---------- Standard device GET endpoints ------------------------------------
+
+func (h *OCHandler) GetConnected(w http.ResponseWriter, r *http.Request) {
+	_, clientTxID := parseGetParams(r)
+	writeJSON(w, okResp(clientTxID, h.nextTxID(), h.holder.IsConnected()))
+}
+
+func (h *OCHandler) GetConnecting(w http.ResponseWriter, r *http.Request) {
+	_, clientTxID := parseGetParams(r)
+	writeJSON(w, okResp(clientTxID, h.nextTxID(), false))
+}
+
+func (h *OCHandler) GetDescription(w http.ResponseWriter, r *http.Request) {
+	_, clientTxID := parseGetParams(r)
+	writeJSON(w, okResp(clientTxID, h.nextTxID(), ocDescription))
+}
+
+func (h *OCHandler) GetDriverInfo(w http.ResponseWriter, r *http.Request) {
+	_, clientTxID := parseGetParams(r)
+	writeJSON(w, okResp(clientTxID, h.nextTxID(), ocDriverInfo))
+}
+
+func (h *OCHandler) GetDriverVersion(w http.ResponseWriter, r *http.Request) {
+	_, clientTxID := parseGetParams(r)
+	writeJSON(w, okResp(clientTxID, h.nextTxID(), h.version))
+}
+
+func (h *OCHandler) GetInterfaceVersion(w http.ResponseWriter, r *http.Request) {
+	_, clientTxID := parseGetParams(r)
+	writeJSON(w, okResp(clientTxID, h.nextTxID(), ocInterfaceVersion))
+}
+
+func (h *OCHandler) GetName(w http.ResponseWriter, r *http.Request) {
+	_, clientTxID := parseGetParams(r)
+	writeJSON(w, okResp(clientTxID, h.nextTxID(), ocDeviceName))
+}
+
+func (h *OCHandler) GetSupportedActions(w http.ResponseWriter, r *http.Request) {
+	_, clientTxID := parseGetParams(r)
+	writeJSON(w, okResp(clientTxID, h.nextTxID(), []string{}))
+}
+
+func (h *OCHandler) GetDeviceState(w http.ResponseWriter, r *http.Request) {
+	_, clientTxID := parseGetParams(r)
+	ev := h.holder.Get()
+	items := []DeviceStateItem{
+		{Name: "CloudCover", Value: ev.Values.CloudCoverPercent},
+		{Name: "DewPoint", Value: ev.Values.Dewpoint},
+		{Name: "Humidity", Value: ev.Values.Humidity},
+		{Name: "SkyQuality", Value: ev.Values.SQM},
+		{Name: "Temperature", Value: ev.Values.Temperature},
+		{Name: "TimeStamp", Value: time.Now().UTC().Format(time.RFC3339Nano)},
+	}
+	writeJSON(w, okResp(clientTxID, h.nextTxID(), items))
+}
+
+// ---------- Standard device PUT endpoints ------------------------------------
+
+func (h *OCHandler) PutConnected(w http.ResponseWriter, r *http.Request) {
+	_, clientTxID := parsePutParams(r)
+	serverTxID := h.nextTxID()
+	switch r.FormValue("Connected") {
+	case "true", "True", "TRUE":
+		h.holder.SetConnected(true)
+		writeJSON(w, voidOK(clientTxID, serverTxID))
+	case "false", "False", "FALSE":
+		h.holder.SetConnected(false)
+		writeJSON(w, voidOK(clientTxID, serverTxID))
+	default:
+		writeJSON(w, voidErr(clientTxID, serverTxID, ErrInvalidValue, "Connected must be true or false"))
+	}
+}
+
+func (h *OCHandler) PutConnect(w http.ResponseWriter, r *http.Request) {
+	_, clientTxID := parsePutParams(r)
+	h.holder.SetConnected(true)
+	writeJSON(w, voidOK(clientTxID, h.nextTxID()))
+}
+
+func (h *OCHandler) PutDisconnect(w http.ResponseWriter, r *http.Request) {
+	_, clientTxID := parsePutParams(r)
+	h.holder.SetConnected(false)
+	writeJSON(w, voidOK(clientTxID, h.nextTxID()))
+}
+
+func (h *OCHandler) PutAction(w http.ResponseWriter, r *http.Request) {
+	_, clientTxID := parsePutParams(r)
+	serverTxID := h.nextTxID()
+	action := r.FormValue("Action")
+	writeJSON(w, errResp[string](clientTxID, serverTxID, ErrInvalidOp,
+		"unknown action: "+action+"; no custom actions are supported"))
+}
+
+func (h *OCHandler) PutCommandNotImpl(w http.ResponseWriter, r *http.Request) {
+	_, clientTxID := parsePutParams(r)
+	writeJSON(w, voidErr(clientTxID, h.nextTxID(), ErrNotImplemented, "not implemented"))
+}
+
+// ---------- OC helpers -------------------------------------------------------
+
+// sensorFloat is a shared handler body for OC sensor GET endpoints that require
+// a connected device and valid raw sensor data. getValue receives the current
+// state and returns (value, errNum, errMsg); a non-zero errNum causes an Alpaca
+// error response to be written instead of the value.
+func (h *OCHandler) sensorFloat(w http.ResponseWriter, r *http.Request, getValue func(ev state.EvaluatedState) (float64, int, string)) {
+	_, clientTxID := parseGetParams(r)
+	serverTxID := h.nextTxID()
+	if !h.holder.IsConnected() {
+		writeJSON(w, errResp[float64](clientTxID, serverTxID, ErrNotConnected, "device is not connected"))
+		return
+	}
+	ev := h.holder.Get()
+	if ev.RawSensors == nil {
+		writeJSON(w, errResp[float64](clientTxID, serverTxID, ErrUnspecified, "no sensor data available yet"))
+		return
+	}
+	val, errNum, errMsg := getValue(ev)
+	if errNum != 0 {
+		writeJSON(w, errResp[float64](clientTxID, serverTxID, errNum, errMsg))
+		return
+	}
+	writeJSON(w, okResp(clientTxID, serverTxID, val))
+}
+
+func sensorErrMsg(status int, name string) string {
+	switch status {
+	case 1:
+		return name + " sensor not found"
+	case 2:
+		return name + " sensor read error"
+	case 3:
+		return name + " sensor data stale"
+	default:
+		return fmt.Sprintf("%s sensor unavailable (status %d)", name, status)
+	}
+}
+
+func (h *OCHandler) getNotImplementedFloat(w http.ResponseWriter, r *http.Request) {
+	_, clientTxID := parseGetParams(r)
+	writeJSON(w, errResp[float64](clientTxID, h.nextTxID(), ErrNotImplemented, "sensor not available on SQMeter ESP32"))
+}
+
+// ---------- OC sensor GET endpoints ------------------------------------------
+
+func (h *OCHandler) GetAveragePeriod(w http.ResponseWriter, r *http.Request) {
+	_, clientTxID := parseGetParams(r)
+	writeJSON(w, okResp(clientTxID, h.nextTxID(), 0.0))
+}
+
+func (h *OCHandler) PutAveragePeriod(w http.ResponseWriter, r *http.Request) {
+	_, clientTxID := parsePutParams(r)
+	serverTxID := h.nextTxID()
+	v, err := strconv.ParseFloat(r.FormValue("AveragePeriod"), 64)
+	if err != nil || v != 0.0 {
+		writeJSON(w, voidErr(clientTxID, serverTxID, ErrInvalidValue, "AveragePeriod must be 0; averaging is not supported"))
+		return
+	}
+	writeJSON(w, voidOK(clientTxID, serverTxID))
+}
+
+func (h *OCHandler) GetCloudCover(w http.ResponseWriter, r *http.Request) {
+	h.sensorFloat(w, r, func(ev state.EvaluatedState) (float64, int, string) {
+		if s := ev.RawSensors.IRTemperature.Status; s != 0 {
+			return 0, ErrUnspecified, sensorErrMsg(s, "IR temperature")
+		}
+		return ev.Values.CloudCoverPercent, 0, ""
+	})
+}
+
+func (h *OCHandler) GetDewPoint(w http.ResponseWriter, r *http.Request) {
+	h.sensorFloat(w, r, func(ev state.EvaluatedState) (float64, int, string) {
+		if s := ev.RawSensors.Environment.Status; s != 0 {
+			return 0, ErrUnspecified, sensorErrMsg(s, "environment")
+		}
+		return ev.Values.Dewpoint, 0, ""
+	})
+}
+
+func (h *OCHandler) GetHumidity(w http.ResponseWriter, r *http.Request) {
+	h.sensorFloat(w, r, func(ev state.EvaluatedState) (float64, int, string) {
+		if s := ev.RawSensors.Environment.Status; s != 0 {
+			return 0, ErrUnspecified, sensorErrMsg(s, "environment")
+		}
+		return ev.Values.Humidity, 0, ""
+	})
+}
+
+func (h *OCHandler) GetPressure(w http.ResponseWriter, r *http.Request) {
+	h.sensorFloat(w, r, func(ev state.EvaluatedState) (float64, int, string) {
+		if s := ev.RawSensors.Environment.Status; s != 0 {
+			return 0, ErrUnspecified, sensorErrMsg(s, "environment")
+		}
+		return ev.RawSensors.Environment.Pressure, 0, ""
+	})
+}
+
+func (h *OCHandler) GetSkyBrightness(w http.ResponseWriter, r *http.Request) {
+	h.sensorFloat(w, r, func(ev state.EvaluatedState) (float64, int, string) {
+		if s := ev.RawSensors.LightSensor.Status; s != 0 {
+			return 0, ErrUnspecified, sensorErrMsg(s, "light")
+		}
+		return ev.RawSensors.LightSensor.Lux, 0, ""
+	})
+}
+
+func (h *OCHandler) GetSkyQuality(w http.ResponseWriter, r *http.Request) {
+	h.sensorFloat(w, r, func(ev state.EvaluatedState) (float64, int, string) {
+		if s := ev.RawSensors.LightSensor.Status; s != 0 {
+			return 0, ErrUnspecified, sensorErrMsg(s, "light")
+		}
+		return ev.Values.SQM, 0, ""
+	})
+}
+
+func (h *OCHandler) GetSkyTemperature(w http.ResponseWriter, r *http.Request) {
+	h.sensorFloat(w, r, func(ev state.EvaluatedState) (float64, int, string) {
+		if s := ev.RawSensors.IRTemperature.Status; s != 0 {
+			return 0, ErrUnspecified, sensorErrMsg(s, "IR temperature")
+		}
+		return ev.RawSensors.IRTemperature.ObjectTemp, 0, ""
+	})
+}
+
+func (h *OCHandler) GetTemperature(w http.ResponseWriter, r *http.Request) {
+	h.sensorFloat(w, r, func(ev state.EvaluatedState) (float64, int, string) {
+		if s := ev.RawSensors.Environment.Status; s != 0 {
+			return 0, ErrUnspecified, sensorErrMsg(s, "environment")
+		}
+		return ev.Values.Temperature, 0, ""
+	})
+}
+
+// ---------- timesincemeasurement / sensordescription -------------------------
+
+// ocSupportedSensors maps lower-case ASCOM sensor names to their descriptions.
+var ocSupportedSensors = map[string]string{
+	"cloudcover":     "Cloud cover estimated from IR temperature differential (0-100%)",
+	"dewpoint":       "Dew point temperature from BME280 environmental sensor (C)",
+	"humidity":       "Relative humidity from BME280 environmental sensor (0-100%)",
+	"pressure":       "Atmospheric pressure from BME280 environmental sensor (hPa)",
+	"skybrightness":  "Sky brightness from TSL2591 light sensor (lux)",
+	"skyquality":     "Sky quality (SQM) from TSL2591 light sensor (mag/arcsec2)",
+	"skytemperature": "Sky temperature from MLX90614 IR thermometer (C)",
+	"temperature":    "Ambient temperature from BME280 environmental sensor (C)",
+}
+
+// ocUnsupportedSensors lists sensors that are defined in the OC interface but
+// not available on the SQMeter ESP32.
+var ocUnsupportedSensors = map[string]bool{
+	"rainrate":      true,
+	"starfwhm":      true,
+	"winddirection": true,
+	"windgust":      true,
+	"windspeed":     true,
+}
+
+func (h *OCHandler) GetTimeSinceMeasurement(w http.ResponseWriter, r *http.Request) {
+	_, clientTxID := parseGetParams(r)
+	serverTxID := h.nextTxID()
+	name := strings.ToLower(queryGetCI(r.URL.Query(), "SensorName"))
+
+	if ocUnsupportedSensors[name] {
+		writeJSON(w, errResp[float64](clientTxID, serverTxID, ErrNotImplemented, "sensor not available on SQMeter ESP32: "+name))
+		return
+	}
+	if _, ok := ocSupportedSensors[name]; !ok {
+		writeJSON(w, errResp[float64](clientTxID, serverTxID, ErrInvalidValue, "unknown sensor name: "+name))
+		return
+	}
+	ev := h.holder.Get()
+	if ev.LastSuccessfulPollUTC.IsZero() {
+		writeJSON(w, errResp[float64](clientTxID, serverTxID, ErrUnspecified, "no successful measurement yet"))
+		return
+	}
+	writeJSON(w, okResp(clientTxID, serverTxID, time.Since(ev.LastSuccessfulPollUTC).Seconds()))
+}
+
+func (h *OCHandler) GetSensorDescription(w http.ResponseWriter, r *http.Request) {
+	_, clientTxID := parseGetParams(r)
+	serverTxID := h.nextTxID()
+	name := strings.ToLower(queryGetCI(r.URL.Query(), "SensorName"))
+
+	if ocUnsupportedSensors[name] {
+		writeJSON(w, errResp[string](clientTxID, serverTxID, ErrNotImplemented, "sensor not available on SQMeter ESP32: "+name))
+		return
+	}
+	desc, ok := ocSupportedSensors[name]
+	if !ok {
+		writeJSON(w, errResp[string](clientTxID, serverTxID, ErrInvalidValue, "unknown sensor name: "+name))
+		return
+	}
+	writeJSON(w, okResp(clientTxID, serverTxID, desc))
+}
+
+// ---------- refresh ----------------------------------------------------------
+
+func (h *OCHandler) PutRefresh(w http.ResponseWriter, r *http.Request) {
+	_, clientTxID := parsePutParams(r)
+	if h.refreshFn != nil {
+		h.refreshFn(r.Context())
+	}
+	writeJSON(w, voidOK(clientTxID, h.nextTxID()))
+}

--- a/internal/alpaca/observingconditions_test.go
+++ b/internal/alpaca/observingconditions_test.go
@@ -678,3 +678,133 @@ func TestOC_ClientTransactionID_Echoed(t *testing.T) {
 		t.Errorf("ClientTransactionID: want 77, got %d", env.ClientTransactionID)
 	}
 }
+
+// ---------- driverinfo / driverversion ---------------------------------------
+
+func TestOC_GetDriverInfo_NonEmpty(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	w := ocGET(t, h, "/api/v1/observingconditions/0/driverinfo")
+	var resp alpaca.Response[string]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.Value == "" {
+		t.Error("DriverInfo should not be empty")
+	}
+}
+
+func TestOC_GetDriverVersion_MatchesVersion(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	w := ocGET(t, h, "/api/v1/observingconditions/0/driverversion")
+	var resp alpaca.Response[string]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.Value != "0.1.0-test" {
+		t.Errorf("DriverVersion: want 0.1.0-test, got %q", resp.Value)
+	}
+}
+
+// ---------- PutConnected true/false ------------------------------------------
+
+func TestOC_PutConnected_SetTrue(t *testing.T) {
+	cfgHolder := config.NewHolder(config.Defaults(), "")
+	holder := state.NewHolder(false)
+	h := alpaca.NewOC(cfgHolder, holder, "uuid", "0.1.0", nil)
+	w := ocPUT(t, h, "/api/v1/observingconditions/0/connected",
+		"Connected=true&ClientID=1&ClientTransactionID=1")
+	var resp alpaca.VoidResponse
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != 0 {
+		t.Errorf("unexpected error: %v", resp.ErrorMessage)
+	}
+	if !holder.IsConnected() {
+		t.Error("expected connected after PUT Connected=true")
+	}
+}
+
+func TestOC_PutConnected_SetFalse(t *testing.T) {
+	cfgHolder := config.NewHolder(config.Defaults(), "")
+	holder := state.NewHolder(true)
+	h := alpaca.NewOC(cfgHolder, holder, "uuid", "0.1.0", nil)
+	w := ocPUT(t, h, "/api/v1/observingconditions/0/connected",
+		"Connected=false&ClientID=1&ClientTransactionID=1")
+	var resp alpaca.VoidResponse
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != 0 {
+		t.Errorf("unexpected error: %v", resp.ErrorMessage)
+	}
+	if holder.IsConnected() {
+		t.Error("expected disconnected after PUT Connected=false")
+	}
+}
+
+// ---------- sensor error coverage for remaining sensor functions -------------
+
+func TestOC_CloudCover_IRSensorError_ReturnsUnspecified(t *testing.T) {
+	ev := ocStateWithSensors()
+	ev.RawSensors.IRTemperature.Status = 2
+	h := newOCHandler(true, ev)
+	w := ocGET(t, h, "/api/v1/observingconditions/0/cloudcover")
+	var resp alpaca.Response[float64]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != alpaca.ErrUnspecified {
+		t.Errorf("want ErrUnspecified (%d), got %d", alpaca.ErrUnspecified, resp.ErrorNumber)
+	}
+}
+
+func TestOC_DewPoint_SensorError_ReturnsUnspecified(t *testing.T) {
+	ev := ocStateWithSensors()
+	ev.RawSensors.Environment.Status = 3 // stale data
+	h := newOCHandler(true, ev)
+	w := ocGET(t, h, "/api/v1/observingconditions/0/dewpoint")
+	var resp alpaca.Response[float64]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != alpaca.ErrUnspecified {
+		t.Errorf("want ErrUnspecified (%d), got %d", alpaca.ErrUnspecified, resp.ErrorNumber)
+	}
+}
+
+func TestOC_Humidity_SensorError_ReturnsUnspecified(t *testing.T) {
+	ev := ocStateWithSensors()
+	ev.RawSensors.Environment.Status = 1 // not found
+	h := newOCHandler(true, ev)
+	w := ocGET(t, h, "/api/v1/observingconditions/0/humidity")
+	var resp alpaca.Response[float64]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != alpaca.ErrUnspecified {
+		t.Errorf("want ErrUnspecified (%d), got %d", alpaca.ErrUnspecified, resp.ErrorNumber)
+	}
+}
+
+func TestOC_Pressure_SensorError_ReturnsUnspecified(t *testing.T) {
+	ev := ocStateWithSensors()
+	ev.RawSensors.Environment.Status = 99 // unknown error triggers default branch
+	h := newOCHandler(true, ev)
+	w := ocGET(t, h, "/api/v1/observingconditions/0/pressure")
+	var resp alpaca.Response[float64]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != alpaca.ErrUnspecified {
+		t.Errorf("want ErrUnspecified (%d), got %d", alpaca.ErrUnspecified, resp.ErrorNumber)
+	}
+}
+
+func TestOC_SkyBrightness_SensorError_ReturnsUnspecified(t *testing.T) {
+	ev := ocStateWithSensors()
+	ev.RawSensors.LightSensor.Status = 3 // stale data
+	h := newOCHandler(true, ev)
+	w := ocGET(t, h, "/api/v1/observingconditions/0/skybrightness")
+	var resp alpaca.Response[float64]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != alpaca.ErrUnspecified {
+		t.Errorf("want ErrUnspecified (%d), got %d", alpaca.ErrUnspecified, resp.ErrorNumber)
+	}
+}
+
+func TestOC_SkyTemperature_IRSensorError_ReturnsUnspecified(t *testing.T) {
+	ev := ocStateWithSensors()
+	ev.RawSensors.IRTemperature.Status = 1
+	h := newOCHandler(true, ev)
+	w := ocGET(t, h, "/api/v1/observingconditions/0/skytemperature")
+	var resp alpaca.Response[float64]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != alpaca.ErrUnspecified {
+		t.Errorf("want ErrUnspecified (%d), got %d", alpaca.ErrUnspecified, resp.ErrorNumber)
+	}
+}

--- a/internal/alpaca/observingconditions_test.go
+++ b/internal/alpaca/observingconditions_test.go
@@ -1,0 +1,680 @@
+package alpaca_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"sqmeter-alpaca-safetymonitor/internal/alpaca"
+	"sqmeter-alpaca-safetymonitor/internal/config"
+	"sqmeter-alpaca-safetymonitor/internal/sqmclient"
+	"sqmeter-alpaca-safetymonitor/internal/state"
+)
+
+// ---------- test helpers -----------------------------------------------------
+
+func newOCHandler(connected bool, ev state.EvaluatedState) *alpaca.OCHandler {
+	cfgHolder := config.NewHolder(config.Defaults(), "")
+	holder := state.NewHolder(connected)
+	holder.Update(ev)
+	return alpaca.NewOC(cfgHolder, holder, "oc-uuid-1234-5678-90ab", "0.1.0-test", nil)
+}
+
+// newOCMux registers both a SafetyMonitor (for the /api/ catch-all) and the
+// given OCHandler on a fresh mux.
+func newOCMux(h *alpaca.OCHandler) *http.ServeMux {
+	smHolder := state.NewHolder(true)
+	smCfg := config.NewHolder(config.Defaults(), "")
+	sm := alpaca.New(smCfg, smHolder, "sm-uuid", "0.1.0-test", nil)
+	mux := http.NewServeMux()
+	sm.Register(mux)
+	h.Register(mux)
+	return mux
+}
+
+func ocGET(t *testing.T, h *alpaca.OCHandler, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	mux := newOCMux(h)
+	sep := "?"
+	if strings.Contains(path, "?") {
+		sep = "&"
+	}
+	req := httptest.NewRequest(http.MethodGet, path+sep+"ClientID=1&ClientTransactionID=42", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	return w
+}
+
+func ocPUT(t *testing.T, h *alpaca.OCHandler, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	mux := newOCMux(h)
+	req := httptest.NewRequest(http.MethodPut, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	return w
+}
+
+func goodSensors() *sqmclient.SensorsResponse {
+	return &sqmclient.SensorsResponse{
+		LightSensor: sqmclient.LightSensor{Lux: 0.05, Status: 0},
+		SkyQuality:  sqmclient.SkyQuality{SQM: 21.5, Bortle: 3},
+		Environment: sqmclient.Environment{
+			Temperature: 12.3,
+			Humidity:    55.0,
+			Dewpoint:    3.4,
+			Pressure:    1013.2,
+			Status:      0,
+		},
+		IRTemperature: sqmclient.IRTemperature{
+			ObjectTemp:  -30.0,
+			AmbientTemp: 12.3,
+			Status:      0,
+		},
+		CloudConditions: sqmclient.CloudConditions{
+			CloudCoverPercent: 10.0,
+		},
+	}
+}
+
+func ocStateWithSensors() state.EvaluatedState {
+	now := time.Now().UTC()
+	sensors := goodSensors()
+	return state.EvaluatedState{
+		IsSafe:                true,
+		Reasons:               []string{},
+		Warnings:              []string{},
+		LastSuccessfulPollUTC: now,
+		LastPollUTC:           now,
+		RawSensors:            sensors,
+		Values: state.Values{
+			SQM:               sensors.SkyQuality.SQM,
+			Temperature:       sensors.Environment.Temperature,
+			Humidity:          sensors.Environment.Humidity,
+			Dewpoint:          sensors.Environment.Dewpoint,
+			CloudCoverPercent: sensors.CloudConditions.CloudCoverPercent,
+		},
+	}
+}
+
+// ---------- management: configureddevices lists both devices -----------------
+
+func TestOC_ConfiguredDevices_TwoDevices(t *testing.T) {
+	cfgHolder := config.NewHolder(config.Defaults(), "")
+	holder := state.NewHolder(true)
+	smHandler := alpaca.New(cfgHolder, holder, "sm-uuid-1234", "0.1.0-test", nil)
+	ocHandler := alpaca.NewOC(cfgHolder, holder, "oc-uuid-5678", "0.1.0-test", nil)
+	smHandler.AddConfiguredDevice(ocHandler.ConfiguredDevice())
+
+	mux := http.NewServeMux()
+	smHandler.Register(mux)
+	ocHandler.Register(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/management/v1/configureddevices?ClientID=1&ClientTransactionID=1", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	var resp alpaca.Response[[]alpaca.ConfiguredDevice]
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.ErrorNumber != 0 {
+		t.Fatalf("error: %v", resp.ErrorMessage)
+	}
+	if len(resp.Value) != 2 {
+		t.Fatalf("expected 2 configured devices, got %d", len(resp.Value))
+	}
+	types := map[string]bool{}
+	for _, d := range resp.Value {
+		types[d.DeviceType] = true
+	}
+	if !types["SafetyMonitor"] {
+		t.Error("configureddevices missing SafetyMonitor")
+	}
+	if !types["ObservingConditions"] {
+		t.Error("configureddevices missing ObservingConditions")
+	}
+}
+
+// ---------- standard device endpoints ----------------------------------------
+
+func TestOC_GetConnected_True(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	w := ocGET(t, h, "/api/v1/observingconditions/0/connected")
+	var resp alpaca.Response[bool]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if !resp.Value {
+		t.Error("expected Connected=true")
+	}
+}
+
+func TestOC_GetConnected_False(t *testing.T) {
+	h := newOCHandler(false, ocStateWithSensors())
+	w := ocGET(t, h, "/api/v1/observingconditions/0/connected")
+	var resp alpaca.Response[bool]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.Value {
+		t.Error("expected Connected=false")
+	}
+}
+
+func TestOC_GetConnecting_AlwaysFalse(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	w := ocGET(t, h, "/api/v1/observingconditions/0/connecting")
+	var resp alpaca.Response[bool]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.Value {
+		t.Error("Connecting should always be false")
+	}
+}
+
+func TestOC_GetDescription_NonEmpty(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	w := ocGET(t, h, "/api/v1/observingconditions/0/description")
+	var resp alpaca.Response[string]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.Value == "" {
+		t.Error("Description should not be empty")
+	}
+}
+
+func TestOC_GetInterfaceVersion_IsOne(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	w := ocGET(t, h, "/api/v1/observingconditions/0/interfaceversion")
+	var resp alpaca.Response[int]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.Value != 1 {
+		t.Errorf("InterfaceVersion: want 1, got %d", resp.Value)
+	}
+}
+
+func TestOC_GetName_NonEmpty(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	w := ocGET(t, h, "/api/v1/observingconditions/0/name")
+	var resp alpaca.Response[string]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.Value == "" {
+		t.Error("Name should not be empty")
+	}
+}
+
+func TestOC_GetSupportedActions_Empty(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	w := ocGET(t, h, "/api/v1/observingconditions/0/supportedactions")
+	var resp alpaca.Response[[]string]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != 0 {
+		t.Fatalf("error: %v", resp.ErrorMessage)
+	}
+	if len(resp.Value) != 0 {
+		t.Errorf("expected empty supportedactions, got %v", resp.Value)
+	}
+}
+
+func TestOC_GetDeviceState_ContainsExpectedItems(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	w := ocGET(t, h, "/api/v1/observingconditions/0/devicestate")
+	var resp alpaca.Response[[]alpaca.DeviceStateItem]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != 0 {
+		t.Fatalf("error: %v", resp.ErrorMessage)
+	}
+	names := map[string]bool{}
+	for _, item := range resp.Value {
+		names[item.Name] = true
+	}
+	for _, want := range []string{"Temperature", "Humidity", "CloudCover", "TimeStamp"} {
+		if !names[want] {
+			t.Errorf("DeviceState missing %q, got %v", want, resp.Value)
+		}
+	}
+}
+
+// ---------- connect / disconnect ---------------------------------------------
+
+func TestOC_PutConnect_SetsConnected(t *testing.T) {
+	cfgHolder := config.NewHolder(config.Defaults(), "")
+	holder := state.NewHolder(false)
+	h := alpaca.NewOC(cfgHolder, holder, "uuid", "0.1.0", nil)
+	w := ocPUT(t, h, "/api/v1/observingconditions/0/connect", "ClientID=1&ClientTransactionID=1")
+	var resp alpaca.VoidResponse
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != 0 {
+		t.Errorf("unexpected error: %v", resp.ErrorMessage)
+	}
+	if !holder.IsConnected() {
+		t.Error("expected connected after PUT /connect")
+	}
+}
+
+func TestOC_PutDisconnect_SetsDisconnected(t *testing.T) {
+	cfgHolder := config.NewHolder(config.Defaults(), "")
+	holder := state.NewHolder(true)
+	h := alpaca.NewOC(cfgHolder, holder, "uuid", "0.1.0", nil)
+	w := ocPUT(t, h, "/api/v1/observingconditions/0/disconnect", "ClientID=1&ClientTransactionID=1")
+	var resp alpaca.VoidResponse
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != 0 {
+		t.Errorf("unexpected error: %v", resp.ErrorMessage)
+	}
+	if holder.IsConnected() {
+		t.Error("expected disconnected after PUT /disconnect")
+	}
+}
+
+func TestOC_PutConnected_InvalidValue(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	w := ocPUT(t, h, "/api/v1/observingconditions/0/connected", "Connected=maybe")
+	var resp alpaca.VoidResponse
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber == 0 {
+		t.Error("expected error for invalid Connected value")
+	}
+}
+
+func TestOC_PutAction_ReturnsError(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	w := ocPUT(t, h, "/api/v1/observingconditions/0/action", "Action=anything&ClientID=1&ClientTransactionID=1")
+	var resp alpaca.Response[string]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber == 0 {
+		t.Error("expected error: OC has no custom actions")
+	}
+}
+
+func TestOC_PutCommandBlind_NotImplemented(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	w := ocPUT(t, h, "/api/v1/observingconditions/0/commandblind", "Command=foo")
+	var resp alpaca.VoidResponse
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != alpaca.ErrNotImplemented {
+		t.Errorf("want ErrNotImplemented (%d), got %d", alpaca.ErrNotImplemented, resp.ErrorNumber)
+	}
+}
+
+// ---------- averageperiod ----------------------------------------------------
+
+func TestOC_GetAveragePeriod_ReturnsZero(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	w := ocGET(t, h, "/api/v1/observingconditions/0/averageperiod")
+	var resp alpaca.Response[float64]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != 0 {
+		t.Fatalf("error: %v", resp.ErrorMessage)
+	}
+	if resp.Value != 0.0 {
+		t.Errorf("AveragePeriod: want 0.0, got %f", resp.Value)
+	}
+}
+
+func TestOC_PutAveragePeriod_ZeroAccepted(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	w := ocPUT(t, h, "/api/v1/observingconditions/0/averageperiod", "AveragePeriod=0&ClientID=1")
+	var resp alpaca.VoidResponse
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != 0 {
+		t.Errorf("unexpected error for AveragePeriod=0: %v", resp.ErrorMessage)
+	}
+}
+
+func TestOC_PutAveragePeriod_NonZeroRejected(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	w := ocPUT(t, h, "/api/v1/observingconditions/0/averageperiod", "AveragePeriod=1.5&ClientID=1")
+	var resp alpaca.VoidResponse
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != alpaca.ErrInvalidValue {
+		t.Errorf("want ErrInvalidValue (%d), got %d", alpaca.ErrInvalidValue, resp.ErrorNumber)
+	}
+}
+
+// ---------- sensor happy paths -----------------------------------------------
+
+func TestOC_GetTemperature_Happy(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	w := ocGET(t, h, "/api/v1/observingconditions/0/temperature")
+	var resp alpaca.Response[float64]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != 0 {
+		t.Fatalf("unexpected error: %v", resp.ErrorMessage)
+	}
+	if resp.Value != 12.3 {
+		t.Errorf("Temperature: want 12.3, got %f", resp.Value)
+	}
+}
+
+func TestOC_GetHumidity_Happy(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	w := ocGET(t, h, "/api/v1/observingconditions/0/humidity")
+	var resp alpaca.Response[float64]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != 0 {
+		t.Fatalf("unexpected error: %v", resp.ErrorMessage)
+	}
+	if resp.Value != 55.0 {
+		t.Errorf("Humidity: want 55.0, got %f", resp.Value)
+	}
+}
+
+func TestOC_GetDewPoint_Happy(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	w := ocGET(t, h, "/api/v1/observingconditions/0/dewpoint")
+	var resp alpaca.Response[float64]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != 0 {
+		t.Fatalf("unexpected error: %v", resp.ErrorMessage)
+	}
+	if resp.Value != 3.4 {
+		t.Errorf("DewPoint: want 3.4, got %f", resp.Value)
+	}
+}
+
+func TestOC_GetPressure_Happy(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	w := ocGET(t, h, "/api/v1/observingconditions/0/pressure")
+	var resp alpaca.Response[float64]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != 0 {
+		t.Fatalf("unexpected error: %v", resp.ErrorMessage)
+	}
+	if resp.Value != 1013.2 {
+		t.Errorf("Pressure: want 1013.2, got %f", resp.Value)
+	}
+}
+
+func TestOC_GetSkyQuality_Happy(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	w := ocGET(t, h, "/api/v1/observingconditions/0/skyquality")
+	var resp alpaca.Response[float64]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != 0 {
+		t.Fatalf("unexpected error: %v", resp.ErrorMessage)
+	}
+	if resp.Value != 21.5 {
+		t.Errorf("SkyQuality: want 21.5, got %f", resp.Value)
+	}
+}
+
+func TestOC_GetSkyBrightness_Happy(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	w := ocGET(t, h, "/api/v1/observingconditions/0/skybrightness")
+	var resp alpaca.Response[float64]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != 0 {
+		t.Fatalf("unexpected error: %v", resp.ErrorMessage)
+	}
+	if resp.Value != 0.05 {
+		t.Errorf("SkyBrightness: want 0.05, got %f", resp.Value)
+	}
+}
+
+func TestOC_GetSkyTemperature_Happy(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	w := ocGET(t, h, "/api/v1/observingconditions/0/skytemperature")
+	var resp alpaca.Response[float64]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != 0 {
+		t.Fatalf("unexpected error: %v", resp.ErrorMessage)
+	}
+	if resp.Value != -30.0 {
+		t.Errorf("SkyTemperature: want -30.0, got %f", resp.Value)
+	}
+}
+
+func TestOC_GetCloudCover_Happy(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	w := ocGET(t, h, "/api/v1/observingconditions/0/cloudcover")
+	var resp alpaca.Response[float64]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != 0 {
+		t.Fatalf("unexpected error: %v", resp.ErrorMessage)
+	}
+	if resp.Value != 10.0 {
+		t.Errorf("CloudCover: want 10.0, got %f", resp.Value)
+	}
+}
+
+// ---------- not connected -----------------------------------------------------
+
+func TestOC_SensorEndpoints_NotConnected_ReturnNotConnected(t *testing.T) {
+	paths := []string{
+		"/api/v1/observingconditions/0/temperature",
+		"/api/v1/observingconditions/0/humidity",
+		"/api/v1/observingconditions/0/dewpoint",
+		"/api/v1/observingconditions/0/pressure",
+		"/api/v1/observingconditions/0/skyquality",
+		"/api/v1/observingconditions/0/skybrightness",
+		"/api/v1/observingconditions/0/skytemperature",
+		"/api/v1/observingconditions/0/cloudcover",
+	}
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			h := newOCHandler(false, ocStateWithSensors())
+			w := ocGET(t, h, path)
+			var resp alpaca.Response[float64]
+			json.NewDecoder(w.Body).Decode(&resp)
+			if resp.ErrorNumber != alpaca.ErrNotConnected {
+				t.Errorf("want ErrNotConnected (%d), got %d (%s)",
+					alpaca.ErrNotConnected, resp.ErrorNumber, resp.ErrorMessage)
+			}
+		})
+	}
+}
+
+// ---------- no data yet -------------------------------------------------------
+
+func TestOC_SensorEndpoint_NoData_ReturnsError(t *testing.T) {
+	emptyState := state.EvaluatedState{
+		Reasons:  []string{},
+		Warnings: []string{},
+		// RawSensors nil — no poll has succeeded
+	}
+	h := newOCHandler(true, emptyState)
+	w := ocGET(t, h, "/api/v1/observingconditions/0/temperature")
+	var resp alpaca.Response[float64]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber == 0 {
+		t.Error("expected error when no sensor data is available")
+	}
+}
+
+// ---------- sensor error ------------------------------------------------------
+
+func TestOC_Temperature_SensorError_ReturnsUnspecified(t *testing.T) {
+	ev := ocStateWithSensors()
+	ev.RawSensors.Environment.Status = 2 // read error
+	h := newOCHandler(true, ev)
+	w := ocGET(t, h, "/api/v1/observingconditions/0/temperature")
+	var resp alpaca.Response[float64]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != alpaca.ErrUnspecified {
+		t.Errorf("want ErrUnspecified (%d), got %d", alpaca.ErrUnspecified, resp.ErrorNumber)
+	}
+}
+
+func TestOC_SkyQuality_SensorError_ReturnsUnspecified(t *testing.T) {
+	ev := ocStateWithSensors()
+	ev.RawSensors.LightSensor.Status = 1 // not found
+	h := newOCHandler(true, ev)
+	w := ocGET(t, h, "/api/v1/observingconditions/0/skyquality")
+	var resp alpaca.Response[float64]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != alpaca.ErrUnspecified {
+		t.Errorf("want ErrUnspecified (%d), got %d", alpaca.ErrUnspecified, resp.ErrorNumber)
+	}
+}
+
+// ---------- unsupported sensors -----------------------------------------------
+
+func TestOC_UnsupportedSensors_NotImplemented(t *testing.T) {
+	paths := []string{
+		"/api/v1/observingconditions/0/rainrate",
+		"/api/v1/observingconditions/0/starfwhm",
+		"/api/v1/observingconditions/0/winddirection",
+		"/api/v1/observingconditions/0/windgust",
+		"/api/v1/observingconditions/0/windspeed",
+	}
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			h := newOCHandler(true, ocStateWithSensors())
+			w := ocGET(t, h, path)
+			var resp alpaca.Response[float64]
+			json.NewDecoder(w.Body).Decode(&resp)
+			if resp.ErrorNumber != alpaca.ErrNotImplemented {
+				t.Errorf("want ErrNotImplemented (%d), got %d", alpaca.ErrNotImplemented, resp.ErrorNumber)
+			}
+		})
+	}
+}
+
+// ---------- timesincemeasurement ---------------------------------------------
+
+func TestOC_TimeSinceMeasurement_Supported(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	w := ocGET(t, h, "/api/v1/observingconditions/0/timesincemeasurement?SensorName=temperature")
+	var resp alpaca.Response[float64]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != 0 {
+		t.Fatalf("unexpected error: %v", resp.ErrorMessage)
+	}
+	if resp.Value < 0 {
+		t.Errorf("TimeSinceMeasurement should be >= 0, got %f", resp.Value)
+	}
+}
+
+func TestOC_TimeSinceMeasurement_Unsupported(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	w := ocGET(t, h, "/api/v1/observingconditions/0/timesincemeasurement?SensorName=rainrate")
+	var resp alpaca.Response[float64]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != alpaca.ErrNotImplemented {
+		t.Errorf("want ErrNotImplemented (%d), got %d", alpaca.ErrNotImplemented, resp.ErrorNumber)
+	}
+}
+
+func TestOC_TimeSinceMeasurement_UnknownSensor(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	w := ocGET(t, h, "/api/v1/observingconditions/0/timesincemeasurement?SensorName=bogus")
+	var resp alpaca.Response[float64]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != alpaca.ErrInvalidValue {
+		t.Errorf("want ErrInvalidValue (%d), got %d", alpaca.ErrInvalidValue, resp.ErrorNumber)
+	}
+}
+
+func TestOC_TimeSinceMeasurement_NoData(t *testing.T) {
+	emptyState := state.EvaluatedState{Reasons: []string{}, Warnings: []string{}}
+	h := newOCHandler(true, emptyState)
+	w := ocGET(t, h, "/api/v1/observingconditions/0/timesincemeasurement?SensorName=temperature")
+	var resp alpaca.Response[float64]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber == 0 {
+		t.Error("expected error when no measurement has been taken")
+	}
+}
+
+// ---------- sensordescription ------------------------------------------------
+
+func TestOC_SensorDescription_Supported(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	w := ocGET(t, h, "/api/v1/observingconditions/0/sensordescription?SensorName=temperature")
+	var resp alpaca.Response[string]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != 0 {
+		t.Fatalf("unexpected error: %v", resp.ErrorMessage)
+	}
+	if resp.Value == "" {
+		t.Error("SensorDescription should not be empty")
+	}
+}
+
+func TestOC_SensorDescription_Unsupported(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	w := ocGET(t, h, "/api/v1/observingconditions/0/sensordescription?SensorName=rainrate")
+	var resp alpaca.Response[string]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != alpaca.ErrNotImplemented {
+		t.Errorf("want ErrNotImplemented (%d), got %d", alpaca.ErrNotImplemented, resp.ErrorNumber)
+	}
+}
+
+func TestOC_SensorDescription_Unknown(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	w := ocGET(t, h, "/api/v1/observingconditions/0/sensordescription?SensorName=bogus")
+	var resp alpaca.Response[string]
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != alpaca.ErrInvalidValue {
+		t.Errorf("want ErrInvalidValue (%d), got %d", alpaca.ErrInvalidValue, resp.ErrorNumber)
+	}
+}
+
+// ---------- refresh ----------------------------------------------------------
+
+func TestOC_PutRefresh_CallsRefreshFn(t *testing.T) {
+	refreshCalled := false
+	cfgHolder := config.NewHolder(config.Defaults(), "")
+	holder := state.NewHolder(true)
+	holder.Update(ocStateWithSensors())
+	h := alpaca.NewOC(cfgHolder, holder, "uuid", "0.1.0-test", func(_ context.Context) {
+		refreshCalled = true
+	})
+
+	mux := newOCMux(h)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/observingconditions/0/refresh",
+		strings.NewReader("ClientID=1&ClientTransactionID=1"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	var resp alpaca.VoidResponse
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.ErrorNumber != 0 {
+		t.Fatalf("unexpected error: %v", resp.ErrorMessage)
+	}
+	if !refreshCalled {
+		t.Error("expected refresh function to be called")
+	}
+}
+
+// ---------- bad paths --------------------------------------------------------
+
+func TestOC_BadPath_WrongDeviceType(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	mux := newOCMux(h)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/OBSERVINGCONDITIONS/0/temperature", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code < 400 {
+		t.Errorf("expected 4xx for capitalised device type, got %d", w.Code)
+	}
+}
+
+func TestOC_BadPath_WrongDeviceNumber(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	mux := newOCMux(h)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/observingconditions/1/temperature", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code < 400 {
+		t.Errorf("expected 4xx for device number 1, got %d", w.Code)
+	}
+}
+
+func TestOC_ClientTransactionID_Echoed(t *testing.T) {
+	h := newOCHandler(true, ocStateWithSensors())
+	mux := newOCMux(h)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/observingconditions/0/connected?ClientID=1&ClientTransactionID=77", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	var env struct {
+		ClientTransactionID uint32 `json:"ClientTransactionID"`
+	}
+	json.NewDecoder(w.Body).Decode(&env)
+	if env.ClientTransactionID != 77 {
+		t.Errorf("ClientTransactionID: want 77, got %d", env.ClientTransactionID)
+	}
+}

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -42,3 +42,17 @@ func DefaultUUIDPath(exeDir string) string {
 	}
 	return filepath.Join(exeDir, "device-uuid.txt")
 }
+
+// DefaultOCUUIDPath returns the platform-appropriate default path for the
+// ObservingConditions device UUID file.
+//
+// On Windows:  %ProgramData%\SQMeter SafetyMonitor\device-oc-uuid.txt
+// Other:       <exeDir>/device-oc-uuid.txt
+func DefaultOCUUIDPath(exeDir string) string {
+	if runtime.GOOS == "windows" {
+		if pd := os.Getenv("ProgramData"); pd != "" {
+			return filepath.Join(pd, AppDataDirName, "device-oc-uuid.txt")
+		}
+	}
+	return filepath.Join(exeDir, "device-oc-uuid.txt")
+}

--- a/internal/config/paths_test.go
+++ b/internal/config/paths_test.go
@@ -72,6 +72,37 @@ func TestDefaultUUIDPath_Windows_ProgramData(t *testing.T) {
 	}
 }
 
+// TestDefaultOCUUIDPath_NonWindows verifies that on non-Windows the OC UUID
+// file defaults to the executable directory.
+func TestDefaultOCUUIDPath_NonWindows(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("non-Windows path test skipped on Windows")
+	}
+	exeDir := "/opt/sqmeter"
+	got := config.DefaultOCUUIDPath(exeDir)
+	want := filepath.Join(exeDir, "device-oc-uuid.txt")
+	if got != want {
+		t.Errorf("DefaultOCUUIDPath(%q) = %q, want %q", exeDir, got, want)
+	}
+}
+
+// TestDefaultOCUUIDPath_Windows_ProgramData verifies the Windows ProgramData
+// OC UUID path.
+func TestDefaultOCUUIDPath_Windows_ProgramData(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows ProgramData path test only runs on Windows")
+	}
+	pd := os.Getenv("ProgramData")
+	if pd == "" {
+		t.Skip("ProgramData not set")
+	}
+	got := config.DefaultOCUUIDPath("/any/exe/dir")
+	want := filepath.Join(pd, config.AppDataDirName, "device-oc-uuid.txt")
+	if got != want {
+		t.Errorf("DefaultOCUUIDPath on Windows = %q, want %q", got, want)
+	}
+}
+
 // TestSaveDefault_CreatesParentDirs verifies that SaveDefault creates any
 // missing parent directories (required for the ProgramData path on first install).
 func TestSaveDefault_CreatesParentDirs(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `ObservingConditions` as a second ASCOM Alpaca device on the existing port and polling loop — no duplicate SQMeter polling, no second service
- Exposes 8 real sensor properties (temperature, humidity, dewpoint, pressure, skyquality, skybrightness, skytemperature, cloudcover) from the BME280, TSL2591, and MLX90614 sensors already polled for SafetyMonitor
- Returns `ErrNotImplemented` for the 5 unsupported properties (rainrate, starfwhm, wind*) so clients know not to retry
- `sensordescription` and `timesincemeasurement` are fully implemented; `averageperiod` returns 0 (no averaging)
- `PUT /api/v1/observingconditions/0/refresh` triggers the shared poll immediately
- `/management/v1/configureddevices` now lists both `SafetyMonitor` and `ObservingConditions`
- A separate UUID file (`device-oc-uuid.txt`) persists the OC device UUID independently

## Files changed

| File | Change |
|---|---|
| `internal/alpaca/observingconditions.go` | New `OCHandler` with all OC endpoints |
| `internal/alpaca/observingconditions_test.go` | 40+ tests covering happy paths, sensor errors, unsupported properties, bad paths |
| `internal/alpaca/handlers.go` | `AddConfiguredDevice` + updated `GetConfiguredDevices` |
| `internal/config/paths.go` | `DefaultOCUUIDPath` helper |
| `cmd/sqmeter-alpaca-safetymonitor/main.go` | Load OC UUID, create and register `OCHandler` |
| `README.md` | ObservingConditions properties table, N.I.N.A. setup, curl examples |

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `go vet ./...` — clean
- [x] `gofmt` — no formatting changes
- [ ] ConformU / N.I.N.A. manual validation — not run; the device follows the same Alpaca envelope pattern as the existing SafetyMonitor which has been ConformU-tested