### PR TITLE
Audit and refactor docs around SQMeter ASCOM Alpaca bridge

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,12 +1,12 @@
 # Privacy Policy
 
-SQMeter Alpaca SafetyMonitor is a local bridge between an SQMeter ESP32 device and ASCOM Alpaca clients on your network.
+SQMeter ASCOM Alpaca is a local bridge between an SQMeter ESP32 device and ASCOM Alpaca clients on your network.
 
 ## Data Collection
 
 The application does not collect analytics, telemetry, personal data, or usage data.
 
-It reads sensor values from the SQMeter device URL that you configure and exposes derived SafetyMonitor status through the local Alpaca HTTP API and web interface.
+It reads sensor values from the SQMeter device URL that you configure and exposes SafetyMonitor and ObservingConditions data through the local Alpaca HTTP API and web interface.
 
 ## Network Communication
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,25 @@
-# sqmeter-alpaca-safetymonitor
+# SQMeter ASCOM Alpaca
 
 [![CI](https://github.com/DeanJ87/SQMeter-Safety-Monitor/actions/workflows/ci.yml/badge.svg)](https://github.com/DeanJ87/SQMeter-Safety-Monitor/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/github/DeanJ87/SQMeter-Safety-Monitor/graph/badge.svg?token=I7DHSX92BN)](https://codecov.io/github/DeanJ87/SQMeter-Safety-Monitor)
 
-A standalone **ASCOM Alpaca SafetyMonitor and ObservingConditions** bridge for the [SQMeter ESP32](https://deanj87.github.io/SQMeter/) sky-quality sensor.
+A native **ASCOM Alpaca bridge** for the [SQMeter ESP32](https://deanj87.github.io/SQMeter/) sky-quality sensor.
 
-Runs as a single `.exe` on your N.I.N.A. Windows machine.  No ASCOM COM drivers, no registration, no Visual Studio templates — pure Alpaca over HTTP/UDP.
+Runs as a single `.exe` (or Windows service) on your observatory PC. No ASCOM COM drivers, no ASCOM Remote Server, no Visual Studio templates — pure Alpaca over HTTP/UDP.
 
 [Privacy policy](PRIVACY.md)
+
+---
+
+## Project scope and naming
+
+| Name | Meaning |
+|------|---------|
+| **SQMeter ASCOM Alpaca** | This project — the bridge/service that reads from an SQMeter ESP32 and speaks ASCOM Alpaca. |
+| **SQMeter SafetyMonitor** | The Alpaca `SafetyMonitor` device exposed by this bridge. Used by N.I.N.A. for safety decisions. |
+| **SQMeter ObservingConditions** | The Alpaca `ObservingConditions` device exposed by this bridge. Used by N.I.N.A. for capture metadata (FITS/XISF headers). |
+
+Both devices are served from a single service on the same HTTP port. The binary and Go module are named `sqmeter-alpaca-safetymonitor` (historical) — a rename is tracked as a follow-up task.
 
 ---
 
@@ -19,7 +31,7 @@ Runs as a single `.exe` on your N.I.N.A. Windows machine.  No ASCOM COM drivers,
 - Exposes a standards-compliant **ASCOM Alpaca ObservingConditions** device at the same port
 - Responds to **ASCOM Alpaca UDP discovery** on port 32227 so N.I.N.A. finds both devices automatically
 - Serves a live **web dashboard** at `http://localhost:11111/`
-- Provides a `/status.json` debug endpoint
+- Provides a `/status.json` debug endpoint and a `--diagnostics` CLI command
 
 It answers two questions: **"Is it safe for the observatory to operate right now?"** and **"What are the current sky conditions?"**
 
@@ -27,140 +39,25 @@ It answers two questions: **"Is it safe for the observatory to operate right now
 
 ## Quick start (Windows)
 
-1. Download `sqmeter-alpaca-safetymonitor-windows-amd64.exe` from [Releases](../../releases)
-2. Double-click the exe — a console window will open and the setup page will open automatically on first run
-3. Complete setup at `http://localhost:11111/setup` to point the service at your SQMeter
-4. Browse to `http://localhost:11111` to see the dashboard
-5. In N.I.N.A. → Equipment → Safety Monitor → select **ASCOM Alpaca** and connect
+1. Download `sqmeter-alpaca-safetymonitor-setup-vX.Y.Z.exe` from [Releases](../../releases)
+2. Run the installer as Administrator — it installs the binary, registers a Windows service, and starts it
+3. On first run the setup page opens automatically at `http://localhost:11111/setup`
+4. Complete setup to point the bridge at your SQMeter
+5. Browse to `http://localhost:11111` to see the dashboard
+6. In N.I.N.A. → Equipment → Safety Monitor → select **ASCOM Alpaca** → click **Refresh** → select **SQMeter SafetyMonitor** → **Connect**
+
+For full N.I.N.A. setup (SafetyMonitor + ObservingConditions), see [docs/nina.md](docs/nina.md).
 
 ---
 
-## Upgrading
+## Documentation
 
-The supported upgrade path is **install over the existing version** — you do not need to uninstall first.
-
-### Steps
-
-1. Download the new installer (`sqmeter-alpaca-safetymonitor-setup-vX.Y.Z.exe`) from [Releases](../../releases).
-2. Run the installer as Administrator.
-3. The installer automatically stops and unregisters the running service before replacing the binary, then re-registers and restarts it.
-4. Your `config.json` is never touched by the installer — settings are always preserved across upgrades.
-
-### What the installer does during an upgrade
-
-| Step | Details |
-|------|---------|
-| Stop service | The existing service is stopped and unregistered before the binary is replaced. |
-| Replace binary | The new `sqmeter-alpaca-safetymonitor.exe` is written to the install directory. |
-| Re-register service | The service is registered against the new binary and started. |
-| Config preserved | `config.json` and `device-uuid.txt` in `%ProgramData%\SQMeter SafetyMonitor\` are not modified by the installer. |
-
-### Rollback
-
-To roll back to a previous version, run the older installer over the current installation using the same install-over-existing process. Your `config.json` is unaffected.
-
-### Config schema migration
-
-When a new version introduces a config schema change, the binary migrates the in-memory config automatically on startup. If the on-disk file has an older `config_version`, the binary:
-
-1. Creates a timestamped backup (e.g. `config.20240115T120000Z.bak`) beside `config.json`.
-2. Rewrites `config.json` with the migrated settings.
-
-If the config file has a `config_version` newer than the binary supports, the service will not start — upgrade the binary to match.
-
-### Automatic updates
-
-Automatic update checking is **not implemented**. New releases are published on [GitHub Releases](../../releases). A future tray icon may offer a "check for updates" link to that page.
-
-Run `sqmeter-alpaca-safetymonitor.exe --version` to see the current version and the releases URL.
-
----
-
-## Configuration
-
-Configuration is managed through the web setup UI at `http://localhost:11111/setup`.
-
-### Config file location
-
-| Platform | Default path |
-|----------|-------------|
-| Windows | `%ProgramData%\SQMeter SafetyMonitor\config.json` |
-| Linux / macOS | `<directory containing the executable>/config.json` |
-
-On Windows the config file lives in `%ProgramData%` (typically `C:\ProgramData\SQMeter SafetyMonitor\config.json`), not beside the `.exe`. This keeps the install directory under `Program Files` free of mutable user data.
-
-Override the path at any time with `--config <path>`.
-
-#### Migrating from an older installation
-
-Versions prior to this release stored `config.json` beside the executable in the install directory (e.g. `C:\Program Files\SQMeter Alpaca SafetyMonitor\config.json`). To migrate manually:
-
-1. Stop the service: `sqmeter-alpaca-safetymonitor.exe --service stop`
-2. Copy `config.json` from the install directory to `%ProgramData%\SQMeter SafetyMonitor\`.
-3. Start the service: `sqmeter-alpaca-safetymonitor.exe --service start`
-
-If no config exists in `%ProgramData%`, the service starts with built-in defaults and the setup page opens automatically.
-
-You can also edit `config.json` directly:
-
-```json
-{
-  "SQMETER_BASE_URL": "http://192.168.1.100",
-  "ALPACA_HTTP_PORT": 11111,
-  "CLOUD_COVER_UNSAFE_PERCENT": 80,
-  "FAIL_CLOSED": true
-}
-```
-
-| Key | Default | Description |
-|-----|---------|-------------|
-| `SQMETER_BASE_URL` | *required* | Base URL of your SQMeter device |
-| `ALPACA_HTTP_BIND` | `127.0.0.1` | HTTP bind address |
-| `ALPACA_HTTP_PORT` | `11111` | HTTP port for Alpaca API + web UI |
-| `ALPACA_DISCOVERY_PORT` | `32227` | UDP port for Alpaca discovery |
-| `POLL_INTERVAL_SECONDS` | `5` | How often to poll the SQMeter |
-| `STALE_AFTER_SECONDS` | `30` | Report unsafe if data is older than this |
-| `FAIL_CLOSED` | `true` | Report unsafe if SQMeter is unreachable |
-| `CONNECTED_ON_STARTUP` | `true` | Start in connected state |
-| `CLOUD_COVER_UNSAFE_PERCENT` | `80` | Cloud cover % that triggers UNSAFE |
-| `CLOUD_COVER_CAUTION_PERCENT` | `50` | Cloud cover % that triggers a warning |
-| `REQUIRE_LIGHT_SENSOR_STATUS_OK` | `true` | Unsafe if light sensor reports error |
-| `REQUIRE_ENVIRONMENT_STATUS_OK` | `true` | Unsafe if env sensor reports error |
-| `REQUIRE_IR_TEMPERATURE_STATUS_OK` | `true` | Unsafe if IR sensor reports error |
-| `SQM_MIN_SAFE` | *(off)* | Unsafe if SQM drops below this |
-| `HUMIDITY_MAX_SAFE` | *(off)* | Unsafe if humidity exceeds this |
-| `DEWPOINT_MARGIN_MIN_C` | *(off)* | Unsafe if temp−dewpoint < this (°C) |
-| `MANUAL_OVERRIDE` | `auto` | `auto` \| `force_safe` \| `force_unsafe` |
-| `LOG_LEVEL` | `info` | `debug` \| `info` \| `warn` \| `error` |
-
-Binding `ALPACA_HTTP_BIND` to `0.0.0.0` exposes the service to the network. Only use it on a trusted LAN or behind firewall controls.
-
-### Config file is the source of truth
-
-`config.json` is the authoritative source for all application settings. The setup UI reads and writes it directly. No `.env` file is auto-loaded, and broad application-setting environment variables are not supported.
-
-The only environment variable that influences runtime behaviour is `LOG_LEVEL` (a process/logging concern). All other settings must be in `config.json`.
-
-### CLI flags
-
-| Flag | Description |
-|------|-------------|
-| `--config <path>` | Path to the JSON config file (default: `%ProgramData%\SQMeter SafetyMonitor\config.json` on Windows, `<exedir>/config.json` on other platforms) |
-| `--write-default-config` | Write default settings to `--config` path and exit |
-| `--check-config` | Validate the config file and exit |
-
-For CI or scripted testing, generate a temporary config file and pass it with `--config` rather than relying on environment variables.
-
-### Sensor status codes
-
-The SQMeter reports a `status` field for each sensor:
-
-| Value | Meaning |
-|-------|---------|
-| 0 | OK |
-| 1 | Sensor not found |
-| 2 | Read error |
-| 3 | Stale data |
+- [docs/configuration.md](docs/configuration.md) — config file, all settings, CLI flags, sensor status codes
+- [docs/windows-service.md](docs/windows-service.md) — service install/start/stop/uninstall, NSSM, firewall
+- [docs/upgrading.md](docs/upgrading.md) — upgrade steps, config preservation, schema migration, rollback
+- [docs/nina.md](docs/nina.md) — N.I.N.A. SafetyMonitor and ObservingConditions setup
+- [docs/nina-alpaca-discovery.md](docs/nina-alpaca-discovery.md) — Alpaca discovery deep-dive, port numbers, PowerShell checks, ASCOM Simulators coexistence
+- [docs/troubleshooting.md](docs/troubleshooting.md) — discovery issues, diagnostics CLI, common problems
 
 ---
 
@@ -181,184 +78,9 @@ The bridge declares UNSAFE if **any** of the following are true:
 
 The web UI and `/status.json` always show the reason(s) for any UNSAFE state.
 
----
-
-## curl test examples
-
-```bash
-# Management API
-curl http://localhost:11111/management/apiversions
-curl http://localhost:11111/management/v1/description
-curl http://localhost:11111/management/v1/configureddevices
-
-# SafetyMonitor
-curl "http://localhost:11111/api/v1/safetymonitor/0/issafe?ClientID=1&ClientTransactionID=1"
-curl "http://localhost:11111/api/v1/safetymonitor/0/connected?ClientID=1&ClientTransactionID=2"
-curl "http://localhost:11111/api/v1/safetymonitor/0/name?ClientID=1&ClientTransactionID=3"
-
-# ObservingConditions
-curl "http://localhost:11111/api/v1/observingconditions/0/temperature?ClientID=1&ClientTransactionID=1"
-curl "http://localhost:11111/api/v1/observingconditions/0/humidity?ClientID=1&ClientTransactionID=2"
-curl "http://localhost:11111/api/v1/observingconditions/0/skyquality?ClientID=1&ClientTransactionID=3"
-curl "http://localhost:11111/api/v1/observingconditions/0/cloudcover?ClientID=1&ClientTransactionID=4"
-curl "http://localhost:11111/api/v1/observingconditions/0/dewpoint?ClientID=1&ClientTransactionID=5"
-curl "http://localhost:11111/api/v1/observingconditions/0/pressure?ClientID=1&ClientTransactionID=6"
-curl "http://localhost:11111/api/v1/observingconditions/0/skytemperature?ClientID=1&ClientTransactionID=7"
-curl "http://localhost:11111/api/v1/observingconditions/0/skybrightness?ClientID=1&ClientTransactionID=8"
-
-# Trigger an immediate sensor refresh (ObservingConditions)
-curl -X PUT http://localhost:11111/api/v1/observingconditions/0/refresh \
-     -d "ClientID=1&ClientTransactionID=20"
-
-# Status / health
-curl http://localhost:11111/status.json
-curl http://localhost:11111/health
-
-# Force refresh via Alpaca action (SafetyMonitor)
-curl -X PUT http://localhost:11111/api/v1/safetymonitor/0/action \
-     -d "Action=refresh&ClientID=1&ClientTransactionID=10"
-
-# Disconnect
-curl -X PUT http://localhost:11111/api/v1/safetymonitor/0/connected \
-     -d "Connected=false&ClientID=1&ClientTransactionID=11"
-```
-
----
-
-## N.I.N.A. setup
-
-### SafetyMonitor
-
-1. Start `sqmeter-alpaca-safetymonitor.exe`
-2. Open N.I.N.A.
-3. Go to **Equipment → Safety Monitor**
-4. In the device selector, choose **ASCOM Alpaca**
-5. Click the **Refresh** / discovery button — **SQMeter SafetyMonitor** should appear
-6. Select it and click **Connect**
-7. Watch the IsSafe indicator; verify it matches `http://localhost:11111/status.json`
-
-### ObservingConditions
-
-1. Go to **Equipment → Weather**
-2. In the device selector, choose **ASCOM Alpaca**
-3. Click **Refresh** — **SQMeter ObservingConditions** should appear alongside the SafetyMonitor
-4. Select it and click **Connect**
-
-Both devices are served from the same port and share the same SQMeter polling loop — no extra configuration required.
-
-If discovery does not work, manually add the device:
-
-- Host: `127.0.0.1`
-- Port: `11111`
-- Device type: `SafetyMonitor` or `ObservingConditions`
-- Device number: `0`
-
-For a full explanation of how Alpaca discovery works, how to verify it manually,
-and how to troubleshoot conflicts with ASCOM Alpaca Simulators, see
-[docs/nina-alpaca-discovery.md](docs/nina-alpaca-discovery.md).
-
----
-
-## Web-based service controls
-
-The dashboard at `http://localhost:11111/` includes **Restart service** and
-**Stop service** buttons once the service is running. Both actions require a
-browser confirmation before executing.
-
-- **Restart** — the process exits with code 1. If the service manager is
-  configured to restart on failure (Windows Service recovery options, NSSM
-  `AppExit` policy, or `systemd Restart=on-failure`), the process restarts
-  automatically. If no restart policy is configured the process simply exits.
-- **Stop** — the process exits cleanly (code 0) and stays stopped until
-  manually restarted. N.I.N.A. and all Alpaca clients lose safety integration
-  while the service is stopped.
-
-Both controls use `POST` requests; plain navigation links (`GET`) cannot
-trigger them. If the service is bound to a non-loopback address
-(`ALPACA_HTTP_BIND=0.0.0.0`) the dashboard displays a network-reachability
-warning next to the controls.
-
-> **Note:** True automatic restart after a web-triggered restart is only
-> guaranteed when the service manager is explicitly configured for it. The
-> service itself cannot restart its own process; it signals intent through the
-> exit code.
-
----
-
-## Running as a Windows service
-
-### Option A: NSSM (recommended)
-
-```cmd
-nssm install SQMeterAlpaca "C:\path\to\sqmeter-alpaca-safetymonitor.exe"
-nssm set SQMeterAlpaca AppDirectory "C:\path\to\"
-nssm set SQMeterAlpaca AppStdout "C:\path\to\logs\out.log"
-nssm set SQMeterAlpaca AppStderr "C:\path\to\logs\err.log"
-nssm start SQMeterAlpaca
-```
-
-### Option B: Task Scheduler
-
-1. Open Task Scheduler → Create Task
-2. Trigger: At system startup
-3. Action: Start a program → path to exe
-4. Set "Run whether user is logged on or not"
-
----
-
-## Firewall (Windows)
-
-Allow the HTTP and UDP ports through Windows Firewall (run as Administrator):
-
-```cmd
-netsh advfirewall firewall add rule name="SQMeter Alpaca HTTP" dir=in action=allow protocol=TCP localport=11111
-netsh advfirewall firewall add rule name="SQMeter Alpaca Discovery" dir=in action=allow protocol=UDP localport=32227
-```
-
----
-
-## Building from source
-
-```bash
-git clone https://github.com/your-org/sqmeter-alpaca-safetymonitor
-cd sqmeter-alpaca-safetymonitor
-make build          # ./bin/sqmeter-alpaca-safetymonitor (current platform)
-make build-windows  # ./dist/sqmeter-alpaca-safetymonitor-windows-amd64.exe
-make test           # run all tests with race detector
-make lint           # gofmt check + go vet
-```
-
-Build artifacts go into `./bin/` and `./dist/` — both are git-ignored.
-
-### Version injection
-
-```bash
-VERSION=v0.1.0 make build
-```
-
-Or GoReleaser handles this automatically on tagged releases.
-
-### Module path
-
-If you fork this repository, update the module path in `go.mod` and all
-`import` statements from `github.com/sqmeter-alpaca/sqmeter-alpaca-safetymonitor`
-to your own path.
-
----
-
-## GitHub Actions
-
-| Workflow | Trigger | Jobs |
-|----------|---------|------|
-| `ci.yml` | push/PR to `main` | lint, test, build Windows + Linux |
-| `release.yml` | `v*.*.*` tag pushed | tests + GoReleaser → GitHub Release |
-
-To publish a release:
-
-```bash
-git tag v0.1.0
-git push origin v0.1.0
-```
+> **Important:** This is a safety integration. Test thoroughly before using it
+> for automated roof or dome control. Verify IsSafe behaviour against known
+> sensor conditions before relying on it for automation.
 
 ---
 
@@ -385,12 +107,70 @@ When a sensor is temporarily unavailable (hardware error, stale data), the prope
 
 ---
 
+## curl quick-test
+
+```bash
+# List all Alpaca devices served by this bridge
+curl http://localhost:11111/management/v1/configureddevices
+
+# SafetyMonitor — is it safe?
+curl "http://localhost:11111/api/v1/safetymonitor/0/issafe?ClientID=1&ClientTransactionID=1"
+
+# ObservingConditions — sky quality
+curl "http://localhost:11111/api/v1/observingconditions/0/skyquality?ClientID=1&ClientTransactionID=1"
+
+# Health and full status
+curl http://localhost:11111/health
+curl http://localhost:11111/status.json
+```
+
+See [docs/nina-alpaca-discovery.md](docs/nina-alpaca-discovery.md) for a complete curl/PowerShell reference.
+
+---
+
+## Building from source
+
+```bash
+git clone https://github.com/DeanJ87/SQMeter-Safety-Monitor
+cd SQMeter-Safety-Monitor
+make build          # ./bin/sqmeter-alpaca-safetymonitor (current platform)
+make build-windows  # ./dist/sqmeter-alpaca-safetymonitor-windows-amd64.exe
+make test           # run all tests with race detector
+make lint           # gofmt check + go vet
+```
+
+Build artifacts go into `./bin/` and `./dist/` — both are git-ignored.
+
+### Version injection
+
+```bash
+VERSION=v0.1.0 make build
+```
+
+Or GoReleaser handles this automatically on tagged releases.
+
+---
+
+## GitHub Actions
+
+| Workflow | Trigger | Jobs |
+|----------|---------|------|
+| `ci.yml` | push/PR to `main` | lint, test, build Windows + Linux, ASCOM Conform |
+| `release.yml` | `v*.*.*` tag pushed | tests + GoReleaser → GitHub Release + Windows installer |
+
+To publish a release:
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+---
+
 ## Alpaca Conform testing
 
-For ASCOM Conform Universal testing:
-
 1. Download [ASCOM Conform Universal](https://github.com/ASCOMInitiative/ConformU/releases)
-2. Configure it to connect to your Alpaca device at `http://127.0.0.1:11111` device `0`
+2. Connect to `http://127.0.0.1:11111`, device `0`
 3. Run the SafetyMonitor conformance check; repeat for ObservingConditions
 
 Target: `v1.0.0` once all Conform tests pass.
@@ -402,14 +182,3 @@ Target: `v1.0.0` once all Conform tests pass.
 - `v0.1.0` — initial usable release
 - `v0.2.x` — feature additions
 - `v1.0.0` — after Alpaca Conform testing passes
-
----
-
-## Branch naming
-
-| Pattern | Use |
-|---------|-----|
-| `main` | stable, CI-protected |
-| `feature/alpaca-safetymonitor` | new features |
-| `fix/discovery-response` | bug fixes |
-| `chore/ci-release` | CI/build changes |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,139 @@
+# Configuration
+
+All runtime settings for SQMeter ASCOM Alpaca live in a single JSON file,
+`config.json`. The web setup UI at `http://localhost:11111/setup` reads and
+writes this file directly.
+
+---
+
+## Config file location
+
+| Platform | Default path |
+|----------|-------------|
+| Windows | `%ProgramData%\SQMeter SafetyMonitor\config.json` |
+| Linux / macOS | `<directory containing the executable>/config.json` |
+
+On Windows the config file lives in `%ProgramData%`
+(typically `C:\ProgramData\SQMeter SafetyMonitor\config.json`), not beside the
+`.exe`. This keeps the install directory under `Program Files` free of mutable
+user data.
+
+Override the path at runtime with `--config <path>`.
+
+---
+
+## Source of truth
+
+`config.json` is the authoritative source for all application settings.
+
+- No `.env` file is auto-loaded.
+- Broad application-setting environment variables are not supported.
+- The only environment variable that influences runtime behaviour is `LOG_LEVEL`
+  (a process/logging concern). All other settings must be in `config.json`.
+- The setup UI reads and writes `config.json` directly. Changes take effect
+  immediately for most settings. Network settings require a service restart
+  (the UI warns you which fields are affected).
+
+---
+
+## Config keys
+
+You can edit `config.json` directly or use the web setup UI. Example minimal
+config:
+
+```json
+{
+  "SQMETER_BASE_URL": "http://192.168.1.100",
+  "ALPACA_HTTP_PORT": 11111,
+  "CLOUD_COVER_UNSAFE_PERCENT": 80,
+  "FAIL_CLOSED": true
+}
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `SQMETER_BASE_URL` | *required* | Base URL of your SQMeter device (e.g. `http://sqmeter.local`) |
+| `ALPACA_HTTP_BIND` | `127.0.0.1` | HTTP bind address. Use `0.0.0.0` for LAN access. **Restart required.** |
+| `ALPACA_HTTP_PORT` | `11111` | HTTP port for Alpaca API and web UI. **Restart required.** |
+| `ALPACA_DISCOVERY_PORT` | `32227` | UDP port for Alpaca discovery. **Restart required.** |
+| `POLL_INTERVAL_SECONDS` | `5` | How often to poll the SQMeter (seconds). Applied immediately. |
+| `STALE_AFTER_SECONDS` | `30` | Report unsafe if data is older than this. Must be ≥ `POLL_INTERVAL_SECONDS`. Applied immediately. |
+| `FAIL_CLOSED` | `true` | Report unsafe when SQMeter is unreachable or data is stale. Applied immediately. |
+| `CONNECTED_ON_STARTUP` | `true` | Start in connected state on next launch. |
+| `CLOUD_COVER_UNSAFE_PERCENT` | `80` | Cloud cover % that triggers UNSAFE. Applied immediately. |
+| `CLOUD_COVER_CAUTION_PERCENT` | `50` | Cloud cover % that triggers a caution warning. Applied immediately. |
+| `REQUIRE_LIGHT_SENSOR_STATUS_OK` | `true` | Report unsafe if light sensor (TSL2591) reports status ≠ 0. Applied immediately. |
+| `REQUIRE_ENVIRONMENT_STATUS_OK` | `true` | Report unsafe if environment sensor (BME280) reports status ≠ 0. Applied immediately. |
+| `REQUIRE_IR_TEMPERATURE_STATUS_OK` | `true` | Report unsafe if IR sensor (MLX90614) reports status ≠ 0. Applied immediately. |
+| `SQM_MIN_SAFE` | *(off)* | Report unsafe if SQM drops below this (mag/arcsec²). Omit to disable. Applied immediately. |
+| `HUMIDITY_MAX_SAFE` | *(off)* | Report unsafe if humidity exceeds this (%). Omit to disable. Applied immediately. |
+| `DEWPOINT_MARGIN_MIN_C` | *(off)* | Report unsafe if (temperature − dew point) < this margin (°C). Omit to disable. Applied immediately. |
+| `MANUAL_OVERRIDE` | `auto` | `auto` — use safety rules; `force_safe` — bypass all rules; `force_unsafe` — always report UNSAFE. Applied immediately. |
+| `LOG_LEVEL` | `info` | `debug` \| `info` \| `warn` \| `error`. Can also be set by the `LOG_LEVEL` environment variable. |
+| `config_version` | *(managed)* | Schema version. Managed automatically — do not edit by hand. |
+
+### Restart-required fields
+
+Changing `ALPACA_HTTP_BIND`, `ALPACA_HTTP_PORT`, or `ALPACA_DISCOVERY_PORT`
+requires a service restart before the new values take effect. The setup UI
+displays a warning banner listing which fields need a restart after you save.
+
+### Network security
+
+Binding `ALPACA_HTTP_BIND` to `0.0.0.0` exposes the service on all network
+interfaces. Only do this on a trusted LAN. Do not expose these ports to the
+internet. The dashboard shows a warning banner when the service is reachable
+from the network.
+
+---
+
+## CLI flags
+
+| Flag | Description |
+|------|-------------|
+| `--config <path>` | Path to the JSON config file (overrides the platform default) |
+| `--write-default-config` | Write default settings to the `--config` path and exit |
+| `--check-config` | Validate the config file and exit with a summary |
+| `--diagnostics` | Print a live diagnostics report (requires the service to be running) |
+| `--version` | Print version, commit, build date, and the releases URL |
+| `--service <cmd>` | Manage the Windows service: `install` \| `uninstall` \| `start` \| `stop` \| `status` |
+
+For CI or scripted testing, generate a temporary config file and pass it with
+`--config` rather than relying on environment variables.
+
+---
+
+## Sensor status codes
+
+The SQMeter reports a `status` field for each sensor:
+
+| Value | Meaning |
+|-------|---------|
+| `0` | OK |
+| `1` | Sensor not found |
+| `2` | Read error |
+| `3` | Stale data |
+
+When `REQUIRE_*_STATUS_OK` is set to `true` and a sensor reports status ≠ 0,
+the bridge reports UNSAFE. The reason is displayed in the web UI and in
+`/status.json`.
+
+---
+
+## Diagnostics
+
+Run the diagnostics command while the service is running:
+
+```cmd
+sqmeter-alpaca-safetymonitor.exe --diagnostics
+```
+
+This queries `GET /api/diagnostics` on the running service and prints a
+structured report covering version, config, discovery health, poller state,
+and current safety status.
+
+The same data is available in JSON format at:
+
+```
+http://localhost:11111/api/diagnostics
+```

--- a/docs/nina-alpaca-discovery.md
+++ b/docs/nina-alpaca-discovery.md
@@ -1,15 +1,21 @@
 # N.I.N.A. Alpaca discovery setup and troubleshooting
 
-This document explains how ASCOM Alpaca discovery works, how to connect SQMeter
-SafetyMonitor in N.I.N.A., and how to diagnose problems when the device does not
-appear or when another Alpaca server (such as ASCOM Alpaca Simulators) is
-interfering.
+This document explains how ASCOM Alpaca discovery works, how to connect the
+SQMeter ASCOM Alpaca bridge in N.I.N.A., and how to diagnose problems when
+devices do not appear or when another Alpaca server (such as ASCOM Alpaca
+Simulators) is interfering.
 
 ---
 
-## How this device appears in N.I.N.A.
+## How this bridge appears in N.I.N.A.
 
-SQMeter SafetyMonitor is a **native ASCOM Alpaca SafetyMonitor** device.
+**SQMeter ASCOM Alpaca** is a **native ASCOM Alpaca bridge** — it speaks the
+Alpaca HTTP protocol directly and exposes two devices from a single service:
+
+| Alpaca device | N.I.N.A. equipment category | Purpose |
+|---|---|---|
+| `SQMeter SafetyMonitor` | Equipment → Safety Monitor | Safety decisions (IsSafe) |
+| `SQMeter ObservingConditions` | Equipment → Weather | Capture metadata, FITS/XISF headers |
 
 - It runs an HTTP Alpaca API on port `11111` by default.
 - It listens on UDP port `32227` for Alpaca discovery broadcasts.
@@ -19,15 +25,20 @@ In N.I.N.A., go to **Equipment → Safety Monitor**, select **ASCOM Alpaca** in
 the driver selector, and click the refresh/discovery button. N.I.N.A. will send
 a UDP discovery broadcast, receive a reply from each Alpaca server on the
 network, and then query `/management/v1/configureddevices` on each one.
-SQMeter SafetyMonitor will appear as:
+The bridge will report both devices:
 
 ```
 DeviceName: SQMeter SafetyMonitor
 DeviceType: SafetyMonitor
 DeviceNumber: 0
+
+DeviceName: SQMeter ObservingConditions
+DeviceType: ObservingConditions
+DeviceNumber: 0
 ```
 
-Select it and click **Connect**.
+Select the appropriate device for each N.I.N.A. equipment slot and click
+**Connect**.
 
 ---
 
@@ -43,7 +54,7 @@ standard.
 
 **`11111` is still Alpaca.** It is a common misconception that port `11111` is
 reserved for ASCOM Remote Server. Port `11111` is simply the default Alpaca HTTP
-port used by many Alpaca servers. SQMeter SafetyMonitor uses it as its default,
+port used by many Alpaca servers. SQMeter ASCOM Alpaca uses it as its default,
 and you can change it in `config.json`.
 
 **`32227` is the discovery port.** N.I.N.A. (and other Alpaca clients) broadcast
@@ -57,7 +68,7 @@ Alpaca server that is listening replies with a JSON packet:
 The client then makes an HTTP request to that port to enumerate devices.
 
 Multiple Alpaca servers can share UDP port `32227` simultaneously. On Windows,
-SQMeter SafetyMonitor uses `SO_REUSEADDR` so it can coexist with other Alpaca
+SQMeter ASCOM Alpaca uses `SO_REUSEADDR` so it can coexist with other Alpaca
 servers such as ASCOM Alpaca Simulators. Each server replies independently with
 its own HTTP port.
 
@@ -65,7 +76,7 @@ Example when both servers are running:
 
 | Server | UDP reply |
 |--------|-----------|
-| SQMeter SafetyMonitor | `{"AlpacaPort": 11111}` |
+| SQMeter ASCOM Alpaca | `{"AlpacaPort": 11111}` |
 | ASCOM Alpaca Simulators | `{"AlpacaPort": 32323}` |
 
 N.I.N.A. queries both and lists all devices it finds.
@@ -81,7 +92,7 @@ in-process DLLs) over the Alpaca HTTP protocol. Use it when you have an existing
 COM driver and want to reach it from a remote machine or from software that
 prefers Alpaca.
 
-SQMeter SafetyMonitor is already a native Alpaca server. It speaks the Alpaca
+SQMeter ASCOM Alpaca is already a native Alpaca server. It speaks the Alpaca
 HTTP protocol directly, with no COM layer. Installing or running ASCOM Remote
 Server alongside it is harmless but unnecessary.
 
@@ -110,6 +121,12 @@ Expected output for `configureddevices`:
     {
       "DeviceName": "SQMeter SafetyMonitor",
       "DeviceType": "SafetyMonitor",
+      "DeviceNumber": 0,
+      "UniqueID": "..."
+    },
+    {
+      "DeviceName": "SQMeter ObservingConditions",
+      "DeviceType": "ObservingConditions",
       "DeviceNumber": 0,
       "UniqueID": "..."
     }
@@ -194,7 +211,7 @@ while ([DateTime]::UtcNow -lt $deadline) {
 $udp.Close()
 ```
 
-**Expected output** when SQMeter SafetyMonitor is running:
+**Expected output** when SQMeter ASCOM Alpaca is running:
 
 ```
 Reply from 127.0.0.1:32227 => {"AlpacaPort":11111}
@@ -206,8 +223,8 @@ If ASCOM Alpaca Simulators is also running, you will see a second line:
 Reply from 127.0.0.1:32227 => {"AlpacaPort":32323}
 ```
 
-If you see only the Simulators line and not the SQMeter line, the SQMeter
-SafetyMonitor service is not running or not listening on UDP — see
+If you see only the Simulators line and not the SQMeter line, the bridge
+service is not running or not listening on UDP — see
 [Troubleshooting](#troubleshooting) below.
 
 ---
@@ -234,10 +251,10 @@ in UDP discovery.
 
 ### Only ASCOM Alpaca Simulators appears in N.I.N.A.
 
-The Simulators responded to discovery but SQMeter SafetyMonitor did not. This
+The Simulators responded to discovery but SQMeter ASCOM Alpaca did not. This
 usually means one of:
 
-- **SQMeter SafetyMonitor is not running.** Start `sqmeter-alpaca-safetymonitor.exe`.
+- **The bridge is not running.** Start `sqmeter-alpaca-safetymonitor.exe`.
 - **Discovery listener failed to bind.** Check `/status.json` → `discovery.healthy`.
 - **Firewall is blocking UDP 32227 inbound.** See [Firewall](#firewall).
 - **You are connecting from a different machine** and the service is bound to
@@ -245,7 +262,7 @@ usually means one of:
   loopback-only listener.
 
 The Simulators appearing proves that discovery itself works. The issue is specific
-to the SQMeter SafetyMonitor listener.
+to the SQMeter ASCOM Alpaca discovery listener.
 
 ### Service is bound to `127.0.0.1` but you need LAN access
 
@@ -275,7 +292,7 @@ After adding the rules, re-run the UDP discovery check to confirm.
 an error. The `last_error` field contains the specific message.
 
 Common cause: another process bound port `32227` without `SO_REUSEADDR` before
-SQMeter SafetyMonitor started. Find the owner with:
+the bridge started. Find the owner with:
 
 ```powershell
 netstat -ano | findstr ":32227"
@@ -283,8 +300,8 @@ Get-Process -Id <PID>
 ```
 
 If the conflict is with ASCOM Alpaca Simulators, try stopping the Simulators
-first, restarting SQMeter SafetyMonitor, then starting the Simulators again.
-Both should coexist once SQMeter SafetyMonitor has successfully bound with
+first, restarting SQMeter ASCOM Alpaca, then starting the Simulators again.
+Both should coexist once the bridge has successfully bound with
 `SO_REUSEADDR`.
 
 ### The dashboard looks stale but you changed something
@@ -310,4 +327,4 @@ If you are running a remote desktop or SSH session, be aware:
   machine where the service runs.
 
 For cross-machine testing, use the LAN IP address of the machine running
-SQMeter SafetyMonitor (and ensure `ALPACA_HTTP_BIND` is `0.0.0.0`).
+SQMeter ASCOM Alpaca (and ensure `ALPACA_HTTP_BIND` is `0.0.0.0`).

--- a/docs/nina.md
+++ b/docs/nina.md
@@ -1,0 +1,79 @@
+# N.I.N.A. setup
+
+SQMeter ASCOM Alpaca exposes two Alpaca devices from a single service:
+
+| Device | N.I.N.A. equipment slot | Purpose |
+|--------|------------------------|---------|
+| `SQMeter SafetyMonitor` | Equipment → Safety Monitor | Controls whether N.I.N.A. considers it safe to operate (IsSafe) |
+| `SQMeter ObservingConditions` | Equipment → Weather | Provides sky-condition data for capture metadata (FITS/XISF headers) |
+
+Both devices are served from the same HTTP port and share the same SQMeter
+polling loop. No extra configuration is required beyond the initial setup.
+
+---
+
+## SafetyMonitor
+
+1. Start the service (or confirm it is running at `http://localhost:11111`).
+2. Open N.I.N.A.
+3. Go to **Equipment → Safety Monitor**.
+4. In the driver selector, choose **ASCOM Alpaca**.
+5. Click the **Refresh** / discovery button.
+   **SQMeter SafetyMonitor** should appear in the list.
+6. Select it and click **Connect**.
+7. Verify the IsSafe indicator; cross-check against
+   `http://localhost:11111/status.json`.
+
+N.I.N.A. uses the SafetyMonitor IsSafe value for safety-critical decisions such
+as roof/dome automation. Test thoroughly before relying on it for automation.
+
+---
+
+## ObservingConditions
+
+1. Go to **Equipment → Weather** (labelled "Weather" in the N.I.N.A. equipment
+   panel).
+2. In the driver selector, choose **ASCOM Alpaca**.
+3. Click **Refresh** — **SQMeter ObservingConditions** should appear.
+4. Select it and click **Connect**.
+
+N.I.N.A. uses the ObservingConditions values to populate FITS/XISF metadata
+headers on captured images (temperature, humidity, dew point, sky quality, etc.)
+where supported. The exact headers written depend on the N.I.N.A. version and
+the imaging sequence settings.
+
+---
+
+## Manual device entry (if discovery does not work)
+
+If the Refresh button does not show the devices, add them manually:
+
+| Field | SafetyMonitor | ObservingConditions |
+|-------|--------------|-------------------|
+| Host | `127.0.0.1` | `127.0.0.1` |
+| Port | `11111` | `11111` |
+| Device type | `SafetyMonitor` | `ObservingConditions` |
+| Device number | `0` | `0` |
+
+Use the machine's LAN IP address instead of `127.0.0.1` if N.I.N.A. is on a
+different machine (and ensure `ALPACA_HTTP_BIND` is `0.0.0.0` in `config.json`).
+
+---
+
+## Discovery troubleshooting
+
+For a full explanation of Alpaca discovery, port numbers, PowerShell checks,
+and ASCOM Alpaca Simulators coexistence, see
+[docs/nina-alpaca-discovery.md](nina-alpaca-discovery.md).
+
+---
+
+## Notes
+
+- N.I.N.A. (and other Alpaca clients) find both devices via the same UDP
+  discovery broadcast. The bridge replies once; N.I.N.A. then queries
+  `/management/v1/configureddevices` and lists all devices from that server.
+- ASCOM Remote Server is **not required**. This bridge implements the Alpaca
+  protocol natively — there is no COM driver or ASCOM Platform dependency.
+- Both devices share live sensor data. If the SQMeter is unreachable, both the
+  SafetyMonitor (UNSAFE) and ObservingConditions (error responses) reflect this.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,162 @@
+# Troubleshooting
+
+---
+
+## Service is not starting
+
+1. Check the Windows Event Log (Event Viewer → Windows Logs → Application) for
+   errors from `SQMeterAlpacaSafetyMonitor`.
+2. Run from a Command Prompt to see console output directly:
+   ```cmd
+   sqmeter-alpaca-safetymonitor.exe --check-config
+   ```
+   This validates `config.json` and exits with a summary. Fix any reported
+   errors before trying to start the service.
+3. If `config.json` is missing, run:
+   ```cmd
+   sqmeter-alpaca-safetymonitor.exe --write-default-config
+   ```
+   This writes a default config to the platform-appropriate path and exits.
+4. If `config_version` in the config file is newer than the binary supports,
+   the service refuses to start. Upgrade the binary or restore a backup config
+   from `%ProgramData%\SQMeter SafetyMonitor\`.
+
+---
+
+## Running the diagnostics command
+
+While the service is running, open a Command Prompt and run:
+
+```cmd
+sqmeter-alpaca-safetymonitor.exe --diagnostics
+```
+
+This queries `GET /api/diagnostics` on the running service and prints a report
+covering version, config path, HTTP bind and port, discovery health, poller
+state, and current safety status with reasons.
+
+The same data is available as JSON:
+
+```powershell
+curl.exe http://127.0.0.1:11111/api/diagnostics
+```
+
+---
+
+## Alpaca HTTP API not responding
+
+```powershell
+curl.exe http://127.0.0.1:11111/health
+curl.exe http://127.0.0.1:11111/management/apiversions
+```
+
+If these fail:
+
+1. Confirm the service is running:
+   ```cmd
+   sqmeter-alpaca-safetymonitor.exe --service status
+   ```
+2. Confirm the port is bound:
+   ```powershell
+   netstat -ano | findstr ":11111"
+   ```
+3. Check that `ALPACA_HTTP_PORT` in `config.json` matches the port you are
+   querying.
+4. If the service is bound to `127.0.0.1` only, queries from another machine
+   will fail — change `ALPACA_HTTP_BIND` to `0.0.0.0` in `config.json` and
+   restart.
+
+---
+
+## N.I.N.A. cannot find the devices
+
+See [docs/nina-alpaca-discovery.md](nina-alpaca-discovery.md) for full
+discovery troubleshooting, including:
+
+- UDP discovery port checks (PowerShell snippet)
+- Listener/PID checks with `netstat`
+- ASCOM Alpaca Simulators coexistence
+- Manual device entry as a fallback
+
+---
+
+## SafetyMonitor reports UNSAFE unexpectedly
+
+1. Check `http://localhost:11111/status.json` — the `reasons` array lists every
+   active UNSAFE condition.
+2. Check the dashboard at `http://localhost:11111/` — UNSAFE reasons are shown
+   prominently.
+3. Common causes:
+   - SQMeter unreachable and `FAIL_CLOSED=true` (default) — verify the SQMeter
+     URL in `/setup`.
+   - A required sensor (`REQUIRE_*_STATUS_OK`) is reporting a non-zero status
+     code (not found, read error, stale).
+   - Cloud cover above `CLOUD_COVER_UNSAFE_PERCENT`.
+   - `MANUAL_OVERRIDE=force_unsafe`.
+4. Run `--diagnostics` for a structured safety report.
+
+---
+
+## SQMeter connection failing
+
+1. In the web setup at `/setup`, click **Test connection** next to
+   `SQMETER_BASE_URL` to confirm the bridge can reach the sensor.
+2. Verify the SQMeter URL is reachable from the machine running the bridge:
+   ```powershell
+   curl.exe http://<sqmeter-ip>/api/sensors
+   ```
+3. Confirm the SQMeter is on the same LAN and the IP or hostname is correct.
+
+---
+
+## Dashboard looks stale
+
+The web dashboard auto-refreshes every 10 seconds. If it appears stale after
+a config change, do a hard refresh (`Ctrl+Shift+R` in most browsers).
+
+For the live current state:
+
+```powershell
+curl.exe http://127.0.0.1:11111/status.json
+```
+
+---
+
+## Port conflicts
+
+| Port | Protocol | Used for |
+|------|----------|---------|
+| `11111` | TCP | Alpaca HTTP API and web UI |
+| `32227` | UDP | Alpaca discovery |
+
+If another process already holds these ports:
+
+```powershell
+netstat -ano | findstr ":11111"
+netstat -ano | findstr ":32227"
+Get-Process -Id <PID>
+```
+
+Change `ALPACA_HTTP_PORT` or `ALPACA_DISCOVERY_PORT` in `config.json` if you
+cannot free the ports, then restart the service.
+
+---
+
+## Config version mismatch
+
+If the service logs `config_version X is newer than the binary supports`, the
+running binary is older than the config file. Upgrade the binary or restore an
+earlier backup config from `%ProgramData%\SQMeter SafetyMonitor\`.
+
+---
+
+## Firewall blocking ports
+
+Run as Administrator:
+
+```cmd
+netsh advfirewall firewall add rule name="SQMeter Alpaca HTTP" dir=in action=allow protocol=TCP localport=11111
+netsh advfirewall firewall add rule name="SQMeter Alpaca Discovery" dir=in action=allow protocol=UDP localport=32227
+```
+
+The installer does not add these rules automatically.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,0 +1,98 @@
+# Upgrading
+
+The supported upgrade path is **install the new installer over the existing
+version** — you do not need to uninstall first.
+
+---
+
+## Steps
+
+1. Download the new installer (`sqmeter-alpaca-safetymonitor-setup-vX.Y.Z.exe`)
+   from [GitHub Releases](https://github.com/DeanJ87/SQMeter-Safety-Monitor/releases).
+2. Run the installer as Administrator.
+3. The installer stops and unregisters the existing service, replaces the
+   binary, re-registers the service, and starts it.
+4. `config.json` and `device-uuid.txt` in
+   `%ProgramData%\SQMeter SafetyMonitor\` are **never touched** by the
+   installer — your settings are always preserved.
+
+---
+
+## What the installer does during an upgrade
+
+| Step | Details |
+|------|---------|
+| Stop service | The existing service is stopped and unregistered before the binary is replaced, so the running executable is not locked. |
+| Replace binary | The new `sqmeter-alpaca-safetymonitor.exe` is written to the install directory. |
+| Re-register service | The service is registered against the new binary and started. |
+| Config preserved | `config.json`, `device-uuid.txt`, and `device-oc-uuid.txt` in `%ProgramData%\SQMeter SafetyMonitor\` are not modified. |
+
+---
+
+## Config schema migration
+
+When a new version introduces a config schema change, the binary migrates
+the config automatically on startup:
+
+1. The binary reads the on-disk `config.json` and detects a `config_version`
+   older than the current schema version.
+2. It creates a timestamped backup beside `config.json`
+   (e.g. `config.20240115T120000Z.bak`).
+3. It rewrites `config.json` with the migrated settings and the updated
+   `config_version`.
+
+If the on-disk `config_version` is **newer** than the binary supports, the
+service will not start. This means you have downgraded the binary below the
+version that wrote the config. Either upgrade the binary back to match, or
+restore a backup config.
+
+---
+
+## Rollback
+
+To roll back to a previous version:
+
+1. Download the older installer from
+   [GitHub Releases](https://github.com/DeanJ87/SQMeter-Safety-Monitor/releases).
+2. Run it over the current installation using the same install-over-existing
+   process.
+3. `config.json` is unaffected. If the older binary does not understand the
+   current `config_version`, it will refuse to start — restore a backup config
+   from `%ProgramData%\SQMeter SafetyMonitor\` in that case.
+
+---
+
+## Migrating from an older installation (config path change)
+
+Versions prior to the `%ProgramData%` config path change stored `config.json`
+beside the executable (e.g.
+`C:\Program Files\SQMeter Alpaca SafetyMonitor\config.json`).
+
+To migrate manually:
+
+1. Stop the service:
+   ```cmd
+   sqmeter-alpaca-safetymonitor.exe --service stop
+   ```
+2. Copy `config.json` from the install directory to
+   `%ProgramData%\SQMeter SafetyMonitor\`.
+3. Start the service:
+   ```cmd
+   sqmeter-alpaca-safetymonitor.exe --service start
+   ```
+
+If no config exists in `%ProgramData%`, the service starts with built-in
+defaults and opens the setup page automatically on the first interactive run.
+
+---
+
+## Automatic updates
+
+Automatic update checking is **not implemented**. New releases are published on
+[GitHub Releases](https://github.com/DeanJ87/SQMeter-Safety-Monitor/releases).
+
+Run the following to see the currently installed version and the releases URL:
+
+```cmd
+sqmeter-alpaca-safetymonitor.exe --version
+```

--- a/docs/windows-service.md
+++ b/docs/windows-service.md
@@ -1,0 +1,119 @@
+# Windows service
+
+SQMeter ASCOM Alpaca ships with a built-in Windows service wrapper. The Windows
+installer registers and starts the service automatically. You can also manage it
+manually with the CLI flags below.
+
+---
+
+## Service details
+
+| Property | Value |
+|----------|-------|
+| Service name | `SQMeterAlpacaSafetyMonitor` |
+| Display name | `SQMeter Alpaca SafetyMonitor` |
+| Startup type | Automatic (set by installer) |
+| Config / data directory | `%ProgramData%\SQMeter SafetyMonitor\` |
+| Install directory | `%ProgramFiles%\SQMeter Alpaca SafetyMonitor\` (default) |
+
+---
+
+## Service commands
+
+Run these as Administrator from a Command Prompt or PowerShell:
+
+```cmd
+sqmeter-alpaca-safetymonitor.exe --service install
+sqmeter-alpaca-safetymonitor.exe --service start
+sqmeter-alpaca-safetymonitor.exe --service stop
+sqmeter-alpaca-safetymonitor.exe --service status
+sqmeter-alpaca-safetymonitor.exe --service uninstall
+```
+
+The Windows installer handles `install`, `start`, `stop`, and `uninstall`
+automatically during fresh installs and upgrades. You only need to run these
+commands manually for troubleshooting or if you installed the binary without
+using the installer.
+
+---
+
+## Web-based service controls
+
+The dashboard at `http://localhost:11111/` includes **Restart service** and
+**Stop service** buttons when the service is running.
+
+- **Restart** — the process exits with code 1. The Windows Service manager
+  restarts it automatically if the recovery action is set to "Restart the
+  service" (the installer configures this). Without a recovery action the
+  process exits and stays stopped.
+- **Stop** — the process exits cleanly (code 0) and stays stopped until
+  manually restarted with `--service start`.
+
+Both controls use `POST` requests; plain navigation links (`GET`) cannot
+trigger them. If the service is bound to a non-loopback address
+(`ALPACA_HTTP_BIND=0.0.0.0`) the dashboard shows a network-reachability
+warning next to these controls.
+
+> **Note:** Only expose the web UI on a trusted LAN. The Restart and Stop
+> controls stop the safety bridge, causing N.I.N.A. and all Alpaca clients to
+> lose safety integration.
+
+---
+
+## Running without the installer (NSSM)
+
+If you prefer NSSM over the built-in service wrapper:
+
+```cmd
+nssm install SQMeterAlpaca "C:\path\to\sqmeter-alpaca-safetymonitor.exe"
+nssm set SQMeterAlpaca AppDirectory "C:\path\to\"
+nssm set SQMeterAlpaca AppStdout "C:\path\to\logs\out.log"
+nssm set SQMeterAlpaca AppStderr "C:\path\to\logs\err.log"
+nssm set SQMeterAlpaca AppExit Default Restart
+nssm start SQMeterAlpaca
+```
+
+Setting `AppExit Default Restart` enables NSSM to restart the process when a
+web-triggered restart exits with code 1.
+
+---
+
+## Running as a scheduled task (alternative)
+
+1. Open Task Scheduler → Create Task
+2. Trigger: At system startup
+3. Action: Start a program → path to the `.exe`
+4. Set "Run whether user is logged on or not"
+5. Set "Run with highest privileges" if the service needs to bind ports < 1024
+
+Note: A scheduled task does not get the automatic restart behaviour of a
+service manager. Use the built-in service or NSSM if you need automatic
+restart after a web-triggered restart.
+
+---
+
+## Firewall rules
+
+Allow the HTTP and UDP ports through Windows Firewall (run as Administrator):
+
+```cmd
+netsh advfirewall firewall add rule name="SQMeter Alpaca HTTP" dir=in action=allow protocol=TCP localport=11111
+netsh advfirewall firewall add rule name="SQMeter Alpaca Discovery" dir=in action=allow protocol=UDP localport=32227
+```
+
+The installer does not add firewall rules automatically. Add them if N.I.N.A.
+is on a different machine or if discovery does not work from the local machine.
+
+---
+
+## Security notes
+
+- The default bind address is `127.0.0.1` (loopback only). N.I.N.A. running on
+  the same machine can always reach the service.
+- Only change `ALPACA_HTTP_BIND` to `0.0.0.0` if you need to reach the service
+  from another machine on the LAN.
+- Do not expose port `11111` or `32227` to the internet. These ports provide
+  no authentication.
+- The web UI service controls (Restart, Stop) are available to anyone who can
+  reach the web UI. On a LAN-exposed bind address this means anyone on your
+  network can stop the safety bridge.

--- a/internal/web/templates/dashboard.html
+++ b/internal/web/templates/dashboard.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta http-equiv="refresh" content="10">
-<title>SQMeter SafetyMonitor</title>
+<title>SQMeter ASCOM Alpaca</title>
 <style>
   :root {
     --safe-bg:    #0a3d1f;
@@ -148,7 +148,7 @@
 
 <header>
   <div>
-    <h1>SQMeter SafetyMonitor</h1>
+    <h1>SQMeter ASCOM Alpaca</h1>
     <small>ASCOM Alpaca bridge &nbsp;·&nbsp; port {{.HTTPPort}} &nbsp;·&nbsp; uptime {{.Uptime}}</small>
   </div>
   <div style="text-align:right">

--- a/internal/web/templates/setup.html
+++ b/internal/web/templates/setup.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Setup — SQMeter SafetyMonitor</title>
+<title>Setup — SQMeter ASCOM Alpaca</title>
 <style>
   :root {
     --safe-fg:   #2ecc71;
@@ -164,7 +164,7 @@
 <body>
 
 <header>
-  <h1>Setup — SQMeter SafetyMonitor</h1>
+  <h1>Setup — SQMeter ASCOM Alpaca</h1>
   <nav>
     <a href="/">Dashboard</a>
     <a href="/status.json">status.json</a>


### PR DESCRIPTION
## Summary
- Reframes the project documentation around `SQMeter ASCOM Alpaca` / bridge terminology. The README title is now `SQMeter ASCOM Alpaca` and includes a clear "Project scope and naming" table distinguishing the bridge from the two Alpaca devices it exposes (`SQMeter SafetyMonitor` and `SQMeter ObservingConditions`).
- Clarifies SafetyMonitor and ObservingConditions as separate Alpaca devices exposed by one service, documented in a new `docs/nina.md`.
- Updates configuration, installer, upgrade, N.I.N.A., discovery, diagnostics, and troubleshooting docs to match current behaviour, split across new files: `docs/configuration.md`, `docs/windows-service.md`, `docs/upgrading.md`, `docs/troubleshooting.md`.
- Fixes stale `configureddevices` example in `docs/nina-alpaca-discovery.md` to show both devices, and updates bridge-vs-device naming throughout.
- Removes stale "future tray icon" promise from the upgrading section of README.
- Updates web dashboard and setup page `<title>` and `<h1>` to `SQMeter ASCOM Alpaca`.
- Updates `PRIVACY.md` project name.

## Validation
- Documentation review
- `go test ./...` — all packages pass

## Notes
- This PR does not rename the repository, binary, service, installer, or Go module.
- The binary and module remain `sqmeter-alpaca-safetymonitor`; the service display name remains `SQMeter Alpaca SafetyMonitor`. A note in the README project-scope section documents this.

## Follow-up recommendations
- **Repository rename:** Consider renaming `DeanJ87/SQMeter-Safety-Monitor` → `DeanJ87/SQMeter-ASCOM-Alpaca` on GitHub. Requires updating badge URLs, `ReleasesURL` in `internal/config/paths.go`, installer `AppURL`, and any external links.
- **Binary / service name:** Consider renaming the binary to `sqmeter-ascom-alpaca` and the Windows service display name from `SQMeter Alpaca SafetyMonitor` to `SQMeter ASCOM Alpaca`. Requires updating `go.mod` module path, all import paths, CI workflow build targets, GoReleaser config, Inno Setup `ExeName` / `SetupBase`, and service `Name`/`DisplayName` in `main.go`.
- **Go module path:** `module sqmeter-alpaca-safetymonitor` in `go.mod` should become `sqmeter-ascom-alpaca` as part of the binary rename above.
- **AppDataDir / ProgramData path:** `AppDataDirName = "SQMeter SafetyMonitor"` in `internal/config/paths.go` and `#define AppDataDir "SQMeter SafetyMonitor"` in `installer/setup.iss` could be updated to a new name, but this is a **migration-sensitive change** — existing installs would lose their config path. Defer until a migration path is implemented.