### PR TITLE
Update public links for SQMeter ASCOM Alpaca naming

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,6 +63,8 @@ checksum:
 release:
   github:
     owner: "{{ .Env.GITHUB_REPOSITORY_OWNER }}"
+    # TODO(repo-rename): update to SQMeter-ASCOM-Alpaca once the GitHub repo
+    # is actually renamed. Changing this before the rename would break releases.
     name: SQMeter-Safety-Monitor
   draft: false
   prerelease: auto

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SQMeter ASCOM Alpaca
 
-[![CI](https://github.com/DeanJ87/SQMeter-Safety-Monitor/actions/workflows/ci.yml/badge.svg)](https://github.com/DeanJ87/SQMeter-Safety-Monitor/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/github/DeanJ87/SQMeter-Safety-Monitor/graph/badge.svg?token=I7DHSX92BN)](https://codecov.io/github/DeanJ87/SQMeter-Safety-Monitor)
+[![CI](https://github.com/DeanJ87/SQMeter-ASCOM-Alpaca/actions/workflows/ci.yml/badge.svg)](https://github.com/DeanJ87/SQMeter-ASCOM-Alpaca/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/github/DeanJ87/SQMeter-ASCOM-Alpaca/graph/badge.svg?token=I7DHSX92BN)](https://codecov.io/github/DeanJ87/SQMeter-ASCOM-Alpaca)
 
 A native **ASCOM Alpaca bridge** for the [SQMeter ESP32](https://deanj87.github.io/SQMeter/) sky-quality sensor.
 
@@ -39,7 +39,7 @@ It answers two questions: **"Is it safe for the observatory to operate right now
 
 ## Quick start (Windows)
 
-1. Download `sqmeter-alpaca-safetymonitor-setup-vX.Y.Z.exe` from [Releases](../../releases)
+1. Download `sqmeter-alpaca-safetymonitor-setup-vX.Y.Z.exe` from [Releases](https://github.com/DeanJ87/SQMeter-ASCOM-Alpaca/releases)
 2. Run the installer as Administrator — it installs the binary, registers a Windows service, and starts it
 3. On first run the setup page opens automatically at `http://localhost:11111/setup`
 4. Complete setup to point the bridge at your SQMeter
@@ -131,8 +131,8 @@ See [docs/nina-alpaca-discovery.md](docs/nina-alpaca-discovery.md) for a complet
 ## Building from source
 
 ```bash
-git clone https://github.com/DeanJ87/SQMeter-Safety-Monitor
-cd SQMeter-Safety-Monitor
+git clone https://github.com/DeanJ87/SQMeter-ASCOM-Alpaca
+cd SQMeter-ASCOM-Alpaca
 make build          # ./bin/sqmeter-alpaca-safetymonitor (current platform)
 make build-windows  # ./dist/sqmeter-alpaca-safetymonitor-windows-amd64.exe
 make test           # run all tests with race detector

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -8,7 +8,7 @@ version** — you do not need to uninstall first.
 ## Steps
 
 1. Download the new installer (`sqmeter-alpaca-safetymonitor-setup-vX.Y.Z.exe`)
-   from [GitHub Releases](https://github.com/DeanJ87/SQMeter-Safety-Monitor/releases).
+   from [GitHub Releases](https://github.com/DeanJ87/SQMeter-ASCOM-Alpaca/releases).
 2. Run the installer as Administrator.
 3. The installer stops and unregisters the existing service, replaces the
    binary, re-registers the service, and starts it.
@@ -53,7 +53,7 @@ restore a backup config.
 To roll back to a previous version:
 
 1. Download the older installer from
-   [GitHub Releases](https://github.com/DeanJ87/SQMeter-Safety-Monitor/releases).
+   [GitHub Releases](https://github.com/DeanJ87/SQMeter-ASCOM-Alpaca/releases).
 2. Run it over the current installation using the same install-over-existing
    process.
 3. `config.json` is unaffected. If the older binary does not understand the
@@ -89,7 +89,7 @@ defaults and opens the setup page automatically on the first interactive run.
 ## Automatic updates
 
 Automatic update checking is **not implemented**. New releases are published on
-[GitHub Releases](https://github.com/DeanJ87/SQMeter-Safety-Monitor/releases).
+[GitHub Releases](https://github.com/DeanJ87/SQMeter-ASCOM-Alpaca/releases).
 
 Run the following to see the currently installed version and the releases URL:
 

--- a/installer/setup.iss
+++ b/installer/setup.iss
@@ -32,7 +32,7 @@
 
 #define AppName      "SQMeter Alpaca SafetyMonitor"
 #define AppPublisher "DeanJ87"
-#define AppURL       "https://github.com/DeanJ87/SQMeter-Safety-Monitor"
+#define AppURL       "https://github.com/DeanJ87/SQMeter-ASCOM-Alpaca"
 #define ServiceName  "SQMeterAlpacaSafetyMonitor"
 #define ExeName      "sqmeter-alpaca-safetymonitor.exe"
 #define SetupBase    "sqmeter-alpaca-safetymonitor-setup"

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -11,7 +11,10 @@ const (
 	AppDataDirName = "SQMeter SafetyMonitor"
 
 	// ReleasesURL is the canonical URL for checking the latest release.
-	ReleasesURL = "https://github.com/DeanJ87/SQMeter-Safety-Monitor/releases"
+	// NOTE: This URL targets the renamed repository (SQMeter-ASCOM-Alpaca).
+	// Until the GitHub repo is actually renamed, GitHub will redirect from the
+	// old SQMeter-Safety-Monitor URL. Once renamed, no further change is needed.
+	ReleasesURL = "https://github.com/DeanJ87/SQMeter-ASCOM-Alpaca/releases"
 )
 
 // DefaultConfigPath returns the platform-appropriate default path for config.json.


### PR DESCRIPTION
## Summary
- Updates public-facing repository/project links toward SQMeter ASCOM Alpaca naming.
- Keeps binary, service, module, and app data paths unchanged.
- Documents any remaining rename work for later migration PRs.

## Validation
- Documentation review
- `go test ./...` — all packages pass (8/8)

## Notes
- GitHub currently redirects old repo URL (`SQMeter-Safety-Monitor`) to the renamed repo during transition, so updating docs links now is safe.
- `.goreleaser.yaml` `release.name` is left as `SQMeter-Safety-Monitor` with a `TODO(repo-rename)` comment — changing it before the actual GitHub rename would break release publishing.

## Remaining work
The following references cannot safely be updated until the GitHub repo is actually renamed to `SQMeter-ASCOM-Alpaca`:

- `.goreleaser.yaml` `release.name` — controls which GitHub repo GoReleaser publishes releases to; must match the live repo name
- CI/CD badge URLs in README will also need a Codecov slug update if Codecov does not auto-follow the rename

Refs #44