### PR TITLE
Update GoReleaser repository name

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,9 +63,7 @@ checksum:
 release:
   github:
     owner: "{{ .Env.GITHUB_REPOSITORY_OWNER }}"
-    # TODO(repo-rename): update to SQMeter-ASCOM-Alpaca once the GitHub repo
-    # is actually renamed. Changing this before the rename would break releases.
-    name: SQMeter-Safety-Monitor
+    name: SQMeter-ASCOM-Alpaca
   draft: false
   prerelease: auto
 


### PR DESCRIPTION
## Summary
- Updates GoReleaser release repository name after the GitHub repository rename.
- Removes the temporary repo-rename TODO.

## Validation
- Repository has been renamed to SQMeter-ASCOM-Alpaca.
- Codecov confirmed working with the new slug.

Refs #44