### PR TITLE
Rename binary and service to SQMeter ASCOM Alpaca

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,15 +88,15 @@ jobs:
         run: |
           GOOS=windows GOARCH=amd64 go build \
             -ldflags "-X main.version=ci -X main.commit=$GITHUB_SHA -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            -o dist/sqmeter-alpaca-safetymonitor-windows-amd64.exe \
-            ./cmd/sqmeter-alpaca-safetymonitor
+            -o dist/sqmeter-ascom-alpaca-windows-amd64.exe \
+            ./cmd/sqmeter-ascom-alpaca
 
       - name: Build Linux amd64
         run: |
           GOOS=linux GOARCH=amd64 go build \
             -ldflags "-X main.version=ci -X main.commit=$GITHUB_SHA -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            -o dist/sqmeter-alpaca-safetymonitor-linux-amd64 \
-            ./cmd/sqmeter-alpaca-safetymonitor
+            -o dist/sqmeter-ascom-alpaca-linux-amd64 \
+            ./cmd/sqmeter-ascom-alpaca
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -129,14 +129,14 @@ jobs:
           New-Item -ItemType Directory -Force -Path dist | Out-Null
           $date = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
           $ldflags = "-X main.version=ci -X main.commit=${{ github.sha }} -X main.date=$date"
-          go build -ldflags $ldflags -o dist/sqmeter-alpaca-safetymonitor-windows-amd64.exe ./cmd/sqmeter-alpaca-safetymonitor
+          go build -ldflags $ldflags -o dist/sqmeter-ascom-alpaca-windows-amd64.exe ./cmd/sqmeter-ascom-alpaca
 
       - name: Verify Windows executable
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
           $PSNativeCommandUseErrorActionPreference = $true
-          $exe = ".\dist\sqmeter-alpaca-safetymonitor-windows-amd64.exe"
+          $exe = ".\dist\sqmeter-ascom-alpaca-windows-amd64.exe"
 
           $versionOutput = (& $exe --version) -join "`n"
           $versionOutput
@@ -167,8 +167,8 @@ jobs:
         run: |
           go build \
             -ldflags "-X main.version=ci -X main.commit=$GITHUB_SHA -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            -o bin/sqmeter-alpaca-safetymonitor \
-            ./cmd/sqmeter-alpaca-safetymonitor
+            -o bin/sqmeter-ascom-alpaca \
+            ./cmd/sqmeter-ascom-alpaca
 
       - name: Download ConformU
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,8 +59,8 @@ jobs:
           VERSION="${GITHUB_REF_NAME#v}"
           go build \
             -ldflags "-X main.version=${VERSION} -X main.commit=${GITHUB_SHA} -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            -o installer/bin/sqmeter-alpaca-safetymonitor.exe \
-            ./cmd/sqmeter-alpaca-safetymonitor
+            -o installer/bin/sqmeter-ascom-alpaca.exe \
+            ./cmd/sqmeter-ascom-alpaca
 
       - name: Install Inno Setup
         run: choco install innosetup --no-progress -y
@@ -78,7 +78,7 @@ jobs:
           TAG="${GITHUB_REF_NAME}"
           VERSION="${TAG#v}"
           gh release upload "${TAG}" \
-            "installer/Output/sqmeter-alpaca-safetymonitor-setup-${VERSION}.exe" \
+            "installer/Output/sqmeter-ascom-alpaca-setup-${VERSION}.exe" \
             --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,6 +1,6 @@
 version: 2
 
-project_name: sqmeter-alpaca-safetymonitor
+project_name: sqmeter-ascom-alpaca
 
 before:
   hooks:
@@ -9,8 +9,8 @@ before:
 
 builds:
   - id: windows-amd64
-    main: ./cmd/sqmeter-alpaca-safetymonitor
-    binary: sqmeter-alpaca-safetymonitor
+    main: ./cmd/sqmeter-ascom-alpaca
+    binary: sqmeter-ascom-alpaca
     goos: [windows]
     goarch: [amd64]
     ldflags:
@@ -19,8 +19,8 @@ builds:
       - -X main.date={{.Date}}
 
   - id: linux-amd64
-    main: ./cmd/sqmeter-alpaca-safetymonitor
-    binary: sqmeter-alpaca-safetymonitor
+    main: ./cmd/sqmeter-ascom-alpaca
+    binary: sqmeter-ascom-alpaca
     goos: [linux]
     goarch: [amd64]
     ldflags:
@@ -29,8 +29,8 @@ builds:
       - -X main.date={{.Date}}
 
   - id: linux-arm64
-    main: ./cmd/sqmeter-alpaca-safetymonitor
-    binary: sqmeter-alpaca-safetymonitor
+    main: ./cmd/sqmeter-ascom-alpaca
+    binary: sqmeter-ascom-alpaca
     goos: [linux]
     goarch: [arm64]
     ldflags:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BINARY   := sqmeter-alpaca-safetymonitor
+BINARY   := sqmeter-ascom-alpaca
 VERSION  ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 COMMIT   ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 DATE     ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Runs as a single `.exe` (or Windows service) on your observatory PC. No ASCOM CO
 | **SQMeter SafetyMonitor** | The Alpaca `SafetyMonitor` device exposed by this bridge. Used by N.I.N.A. for safety decisions. |
 | **SQMeter ObservingConditions** | The Alpaca `ObservingConditions` device exposed by this bridge. Used by N.I.N.A. for capture metadata (FITS/XISF headers). |
 
-Both devices are served from a single service on the same HTTP port. The binary and Go module are named `sqmeter-alpaca-safetymonitor` (historical) — a rename is tracked as a follow-up task.
+Both devices are served from a single service on the same HTTP port. The binary and Go module are named `sqmeter-ascom-alpaca`.
 
 ---
 
@@ -39,7 +39,7 @@ It answers two questions: **"Is it safe for the observatory to operate right now
 
 ## Quick start (Windows)
 
-1. Download `sqmeter-alpaca-safetymonitor-setup-vX.Y.Z.exe` from [Releases](https://github.com/DeanJ87/SQMeter-ASCOM-Alpaca/releases)
+1. Download `sqmeter-ascom-alpaca-setup-vX.Y.Z.exe` from [Releases](https://github.com/DeanJ87/SQMeter-ASCOM-Alpaca/releases)
 2. Run the installer as Administrator — it installs the binary, registers a Windows service, and starts it
 3. On first run the setup page opens automatically at `http://localhost:11111/setup`
 4. Complete setup to point the bridge at your SQMeter
@@ -133,8 +133,8 @@ See [docs/nina-alpaca-discovery.md](docs/nina-alpaca-discovery.md) for a complet
 ```bash
 git clone https://github.com/DeanJ87/SQMeter-ASCOM-Alpaca
 cd SQMeter-ASCOM-Alpaca
-make build          # ./bin/sqmeter-alpaca-safetymonitor (current platform)
-make build-windows  # ./dist/sqmeter-alpaca-safetymonitor-windows-amd64.exe
+make build          # ./bin/sqmeter-ascom-alpaca (current platform)
+make build-windows  # ./dist/sqmeter-ascom-alpaca-windows-amd64.exe
 make test           # run all tests with race detector
 make lint           # gofmt check + go vet
 ```

--- a/cmd/sqmeter-ascom-alpaca/main.go
+++ b/cmd/sqmeter-ascom-alpaca/main.go
@@ -21,12 +21,12 @@ import (
 	"time"
 
 	"github.com/kardianos/service"
-	"sqmeter-alpaca-safetymonitor/internal/alpaca"
-	"sqmeter-alpaca-safetymonitor/internal/config"
-	"sqmeter-alpaca-safetymonitor/internal/discovery"
-	"sqmeter-alpaca-safetymonitor/internal/poller"
-	"sqmeter-alpaca-safetymonitor/internal/state"
-	"sqmeter-alpaca-safetymonitor/internal/web"
+	"sqmeter-ascom-alpaca/internal/alpaca"
+	"sqmeter-ascom-alpaca/internal/config"
+	"sqmeter-ascom-alpaca/internal/discovery"
+	"sqmeter-ascom-alpaca/internal/poller"
+	"sqmeter-ascom-alpaca/internal/state"
+	"sqmeter-ascom-alpaca/internal/web"
 )
 
 // Injected at build time via -ldflags.
@@ -85,7 +85,7 @@ func (p *program) run(ctx context.Context, interactive bool) {
 	}
 
 	logger := newLogger(cfg.LogLevel)
-	logger.Info("starting sqmeter-alpaca-safetymonitor",
+	logger.Info("starting sqmeter-ascom-alpaca",
 		"version", version,
 		"sqmeter_url", cfg.SQMeterBaseURL,
 		"http_port", cfg.AlpacaHTTPPort,
@@ -237,7 +237,7 @@ func main() {
 	flag.Parse()
 
 	if *showVersion {
-		fmt.Printf("sqmeter-alpaca-safetymonitor %s (commit %s, built %s)\n", version, commit, date)
+		fmt.Printf("sqmeter-ascom-alpaca %s (commit %s, built %s)\n", version, commit, date)
 		fmt.Printf("Latest releases: %s\n", config.ReleasesURL)
 		return
 	}
@@ -293,8 +293,8 @@ func main() {
 	}
 
 	svcConfig := &service.Config{
-		Name:        "SQMeterAlpacaSafetyMonitor",
-		DisplayName: "SQMeter Alpaca SafetyMonitor",
+		Name:        "SQMeterASCOMAlpaca",
+		DisplayName: "SQMeter ASCOM Alpaca",
 		Description: "ASCOM Alpaca SafetyMonitor bridge for SQMeter ESP32. Responds to Alpaca discovery on UDP port 32227.",
 	}
 
@@ -414,8 +414,8 @@ func printDiagnosticsReport(r web.DiagnosticsReport) {
 		return out
 	}
 
-	fmt.Println("sqmeter-alpaca-safetymonitor diagnostics")
-	fmt.Println("=========================================")
+	fmt.Println("sqmeter-ascom-alpaca diagnostics")
+	fmt.Println("================================")
 	fmt.Printf("version:    %s\n", none(r.Version))
 	fmt.Printf("timestamp:  %s\n", r.Timestamp)
 	fmt.Printf("uptime:     %s\n", r.Uptime)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -125,7 +125,7 @@ the bridge reports UNSAFE. The reason is displayed in the web UI and in
 Run the diagnostics command while the service is running:
 
 ```cmd
-sqmeter-alpaca-safetymonitor.exe --diagnostics
+sqmeter-ascom-alpaca.exe --diagnostics
 ```
 
 This queries `GET /api/diagnostics` on the running service and prints a

--- a/docs/nina-alpaca-discovery.md
+++ b/docs/nina-alpaca-discovery.md
@@ -254,7 +254,7 @@ in UDP discovery.
 The Simulators responded to discovery but SQMeter ASCOM Alpaca did not. This
 usually means one of:
 
-- **The bridge is not running.** Start `sqmeter-alpaca-safetymonitor.exe`.
+- **The bridge is not running.** Start `sqmeter-ascom-alpaca.exe`.
 - **Discovery listener failed to bind.** Check `/status.json` → `discovery.healthy`.
 - **Firewall is blocking UDP 32227 inbound.** See [Firewall](#firewall).
 - **You are connecting from a different machine** and the service is bound to

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,16 +5,16 @@
 ## Service is not starting
 
 1. Check the Windows Event Log (Event Viewer → Windows Logs → Application) for
-   errors from `SQMeterAlpacaSafetyMonitor`.
+   errors from `SQMeterASCOMAlpaca`.
 2. Run from a Command Prompt to see console output directly:
    ```cmd
-   sqmeter-alpaca-safetymonitor.exe --check-config
+   sqmeter-ascom-alpaca.exe --check-config
    ```
    This validates `config.json` and exits with a summary. Fix any reported
    errors before trying to start the service.
 3. If `config.json` is missing, run:
    ```cmd
-   sqmeter-alpaca-safetymonitor.exe --write-default-config
+   sqmeter-ascom-alpaca.exe --write-default-config
    ```
    This writes a default config to the platform-appropriate path and exits.
 4. If `config_version` in the config file is newer than the binary supports,
@@ -28,7 +28,7 @@
 While the service is running, open a Command Prompt and run:
 
 ```cmd
-sqmeter-alpaca-safetymonitor.exe --diagnostics
+sqmeter-ascom-alpaca.exe --diagnostics
 ```
 
 This queries `GET /api/diagnostics` on the running service and prints a report
@@ -54,7 +54,7 @@ If these fail:
 
 1. Confirm the service is running:
    ```cmd
-   sqmeter-alpaca-safetymonitor.exe --service status
+   sqmeter-ascom-alpaca.exe --service status
    ```
 2. Confirm the port is bound:
    ```powershell

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -7,7 +7,7 @@ version** — you do not need to uninstall first.
 
 ## Steps
 
-1. Download the new installer (`sqmeter-alpaca-safetymonitor-setup-vX.Y.Z.exe`)
+1. Download the new installer (`sqmeter-ascom-alpaca-setup-vX.Y.Z.exe`)
    from [GitHub Releases](https://github.com/DeanJ87/SQMeter-ASCOM-Alpaca/releases).
 2. Run the installer as Administrator.
 3. The installer stops and unregisters the existing service, replaces the
@@ -23,7 +23,7 @@ version** — you do not need to uninstall first.
 | Step | Details |
 |------|---------|
 | Stop service | The existing service is stopped and unregistered before the binary is replaced, so the running executable is not locked. |
-| Replace binary | The new `sqmeter-alpaca-safetymonitor.exe` is written to the install directory. |
+| Replace binary | The new `sqmeter-ascom-alpaca.exe` is written to the install directory. |
 | Re-register service | The service is registered against the new binary and started. |
 | Config preserved | `config.json`, `device-uuid.txt`, and `device-oc-uuid.txt` in `%ProgramData%\SQMeter SafetyMonitor\` are not modified. |
 
@@ -66,19 +66,19 @@ To roll back to a previous version:
 
 Versions prior to the `%ProgramData%` config path change stored `config.json`
 beside the executable (e.g.
-`C:\Program Files\SQMeter Alpaca SafetyMonitor\config.json`).
+`C:\Program Files\SQMeter ASCOM Alpaca\config.json`).
 
 To migrate manually:
 
 1. Stop the service:
    ```cmd
-   sqmeter-alpaca-safetymonitor.exe --service stop
+   sqmeter-ascom-alpaca.exe --service stop
    ```
 2. Copy `config.json` from the install directory to
    `%ProgramData%\SQMeter SafetyMonitor\`.
 3. Start the service:
    ```cmd
-   sqmeter-alpaca-safetymonitor.exe --service start
+   sqmeter-ascom-alpaca.exe --service start
    ```
 
 If no config exists in `%ProgramData%`, the service starts with built-in
@@ -94,5 +94,5 @@ Automatic update checking is **not implemented**. New releases are published on
 Run the following to see the currently installed version and the releases URL:
 
 ```cmd
-sqmeter-alpaca-safetymonitor.exe --version
+sqmeter-ascom-alpaca.exe --version
 ```

--- a/docs/windows-service.md
+++ b/docs/windows-service.md
@@ -10,11 +10,11 @@ manually with the CLI flags below.
 
 | Property | Value |
 |----------|-------|
-| Service name | `SQMeterAlpacaSafetyMonitor` |
-| Display name | `SQMeter Alpaca SafetyMonitor` |
+| Service name | `SQMeterASCOMAlpaca` |
+| Display name | `SQMeter ASCOM Alpaca` |
 | Startup type | Automatic (set by installer) |
 | Config / data directory | `%ProgramData%\SQMeter SafetyMonitor\` |
-| Install directory | `%ProgramFiles%\SQMeter Alpaca SafetyMonitor\` (default) |
+| Install directory | `%ProgramFiles%\SQMeter ASCOM Alpaca\` (default) |
 
 ---
 
@@ -23,11 +23,11 @@ manually with the CLI flags below.
 Run these as Administrator from a Command Prompt or PowerShell:
 
 ```cmd
-sqmeter-alpaca-safetymonitor.exe --service install
-sqmeter-alpaca-safetymonitor.exe --service start
-sqmeter-alpaca-safetymonitor.exe --service stop
-sqmeter-alpaca-safetymonitor.exe --service status
-sqmeter-alpaca-safetymonitor.exe --service uninstall
+sqmeter-ascom-alpaca.exe --service install
+sqmeter-ascom-alpaca.exe --service start
+sqmeter-ascom-alpaca.exe --service stop
+sqmeter-ascom-alpaca.exe --service status
+sqmeter-ascom-alpaca.exe --service uninstall
 ```
 
 The Windows installer handles `install`, `start`, `stop`, and `uninstall`
@@ -65,7 +65,7 @@ warning next to these controls.
 If you prefer NSSM over the built-in service wrapper:
 
 ```cmd
-nssm install SQMeterAlpaca "C:\path\to\sqmeter-alpaca-safetymonitor.exe"
+nssm install SQMeterAlpaca "C:\path\to\sqmeter-ascom-alpaca.exe"
 nssm set SQMeterAlpaca AppDirectory "C:\path\to\"
 nssm set SQMeterAlpaca AppStdout "C:\path\to\logs\out.log"
 nssm set SQMeterAlpaca AppStderr "C:\path\to\logs\err.log"

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
-module sqmeter-alpaca-safetymonitor
+module sqmeter-ascom-alpaca
 
 go 1.23.0
 
 require github.com/kardianos/service v1.2.4
 
-require golang.org/x/sys v0.34.0 // indirect
+require golang.org/x/sys v0.34.0

--- a/installer/setup.iss
+++ b/installer/setup.iss
@@ -1,4 +1,4 @@
-; SQMeter Alpaca SafetyMonitor - Inno Setup installer script
+; SQMeter ASCOM Alpaca - Inno Setup installer script
 ; Build with: ISCC.exe /DAppVersion=1.2.3 setup.iss
 ;
 ; Upgrade behaviour (install over an existing version):
@@ -30,12 +30,12 @@
   #define AppVersion "dev"
 #endif
 
-#define AppName      "SQMeter Alpaca SafetyMonitor"
+#define AppName      "SQMeter ASCOM Alpaca"
 #define AppPublisher "DeanJ87"
 #define AppURL       "https://github.com/DeanJ87/SQMeter-ASCOM-Alpaca"
-#define ServiceName  "SQMeterAlpacaSafetyMonitor"
-#define ExeName      "sqmeter-alpaca-safetymonitor.exe"
-#define SetupBase    "sqmeter-alpaca-safetymonitor-setup"
+#define ServiceName  "SQMeterASCOMAlpaca"
+#define ExeName      "sqmeter-ascom-alpaca.exe"
+#define SetupBase    "sqmeter-ascom-alpaca-setup"
 ; AppDataDir must match config.AppDataDirName in internal/config/paths.go.
 #define AppDataDir   "SQMeter SafetyMonitor"
 
@@ -115,7 +115,7 @@ Filename: "{app}\{#ExeName}"; Parameters: "--service uninstall"; \
 Name: "{group}\Configuration"; \
   Filename: "{app}\{#ExeName}"; \
   Parameters: ""; \
-  Comment: "Open SQMeter SafetyMonitor configuration (opens browser)"
+  Comment: "Open SQMeter ASCOM Alpaca configuration (opens browser)"
 Name: "{group}\Uninstall {#AppName}"; Filename: "{uninstallexe}"
 
 [Code]

--- a/internal/alpaca/conformu_test.go
+++ b/internal/alpaca/conformu_test.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"testing"
 
-	"sqmeter-alpaca-safetymonitor/internal/alpaca"
+	"sqmeter-ascom-alpaca/internal/alpaca"
 )
 
 // newMux returns a fully registered ServeMux for the given handler.

--- a/internal/alpaca/handlers.go
+++ b/internal/alpaca/handlers.go
@@ -9,8 +9,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"sqmeter-alpaca-safetymonitor/internal/config"
-	"sqmeter-alpaca-safetymonitor/internal/state"
+	"sqmeter-ascom-alpaca/internal/config"
+	"sqmeter-ascom-alpaca/internal/state"
 )
 
 const (
@@ -19,7 +19,7 @@ const (
 	deviceType       = "SafetyMonitor"
 	deviceNumber     = 0
 	description      = "ASCOM Alpaca SafetyMonitor bridge for SQMeter ESP32"
-	driverInfo       = "SQMeter Alpaca SafetyMonitor"
+	driverInfo       = "SQMeter ASCOM Alpaca"
 )
 
 // Handler serves all ASCOM Alpaca endpoints for the SafetyMonitor device.
@@ -190,8 +190,8 @@ func (h *Handler) GetAPIVersions(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) GetServerDescription(w http.ResponseWriter, r *http.Request) {
 	_, clientTxID := parseGetParams(r)
 	writeJSON(w, okResp(clientTxID, h.nextTxID(), ServerDescription{
-		ServerName:          "SQMeter Alpaca SafetyMonitor",
-		Manufacturer:        "sqmeter-alpaca",
+		ServerName:          "SQMeter ASCOM Alpaca",
+		Manufacturer:        "sqmeter-ascom-alpaca",
 		ManufacturerVersion: h.version,
 		Location:            "local",
 	}))

--- a/internal/alpaca/handlers_extra_test.go
+++ b/internal/alpaca/handlers_extra_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"sqmeter-alpaca-safetymonitor/internal/alpaca"
-	"sqmeter-alpaca-safetymonitor/internal/config"
-	"sqmeter-alpaca-safetymonitor/internal/state"
+	"sqmeter-ascom-alpaca/internal/alpaca"
+	"sqmeter-ascom-alpaca/internal/config"
+	"sqmeter-ascom-alpaca/internal/state"
 )
 
 func doPUT(t *testing.T, h *alpaca.Handler, path, body string) *httptest.ResponseRecorder {

--- a/internal/alpaca/handlers_test.go
+++ b/internal/alpaca/handlers_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"sqmeter-alpaca-safetymonitor/internal/alpaca"
-	"sqmeter-alpaca-safetymonitor/internal/config"
-	"sqmeter-alpaca-safetymonitor/internal/state"
+	"sqmeter-ascom-alpaca/internal/alpaca"
+	"sqmeter-ascom-alpaca/internal/config"
+	"sqmeter-ascom-alpaca/internal/state"
 )
 
 func newTestHandler(connected bool, ev state.EvaluatedState) *alpaca.Handler {

--- a/internal/alpaca/observingconditions.go
+++ b/internal/alpaca/observingconditions.go
@@ -9,8 +9,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"sqmeter-alpaca-safetymonitor/internal/config"
-	"sqmeter-alpaca-safetymonitor/internal/state"
+	"sqmeter-ascom-alpaca/internal/config"
+	"sqmeter-ascom-alpaca/internal/state"
 )
 
 const (

--- a/internal/alpaca/observingconditions_test.go
+++ b/internal/alpaca/observingconditions_test.go
@@ -9,10 +9,10 @@ import (
 	"testing"
 	"time"
 
-	"sqmeter-alpaca-safetymonitor/internal/alpaca"
-	"sqmeter-alpaca-safetymonitor/internal/config"
-	"sqmeter-alpaca-safetymonitor/internal/sqmclient"
-	"sqmeter-alpaca-safetymonitor/internal/state"
+	"sqmeter-ascom-alpaca/internal/alpaca"
+	"sqmeter-ascom-alpaca/internal/config"
+	"sqmeter-ascom-alpaca/internal/sqmclient"
+	"sqmeter-ascom-alpaca/internal/state"
 )
 
 // ---------- test helpers -----------------------------------------------------

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,7 +6,7 @@ import (
 	"os"
 )
 
-// Config holds all runtime configuration for sqmeter-alpaca-safetymonitor.
+// Config holds all runtime configuration for sqmeter-ascom-alpaca.
 // Settings are loaded from a JSON config file (see Load). The only
 // environment variable that influences runtime behaviour is LOG_LEVEL, which
 // is a process/logging concern and not a configuration file setting.

--- a/internal/config/config_extra_test.go
+++ b/internal/config/config_extra_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"sqmeter-alpaca-safetymonitor/internal/config"
+	"sqmeter-ascom-alpaca/internal/config"
 )
 
 // ---------- NeedsRestart -----------------------------------------------------

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"sqmeter-alpaca-safetymonitor/internal/config"
+	"sqmeter-ascom-alpaca/internal/config"
 )
 
 func TestDefaults(t *testing.T) {

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"sqmeter-alpaca-safetymonitor/internal/config"
+	"sqmeter-ascom-alpaca/internal/config"
 )
 
 // ---------- Load: version rejection ------------------------------------------

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -11,9 +11,6 @@ const (
 	AppDataDirName = "SQMeter SafetyMonitor"
 
 	// ReleasesURL is the canonical URL for checking the latest release.
-	// NOTE: This URL targets the renamed repository (SQMeter-ASCOM-Alpaca).
-	// Until the GitHub repo is actually renamed, GitHub will redirect from the
-	// old SQMeter-Safety-Monitor URL. Once renamed, no further change is needed.
 	ReleasesURL = "https://github.com/DeanJ87/SQMeter-ASCOM-Alpaca/releases"
 )
 

--- a/internal/config/paths_test.go
+++ b/internal/config/paths_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"sqmeter-alpaca-safetymonitor/internal/config"
+	"sqmeter-ascom-alpaca/internal/config"
 )
 
 // TestDefaultConfigPath_NonWindows verifies that on non-Windows platforms the

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"sqmeter-alpaca-safetymonitor/internal/discovery"
+	"sqmeter-ascom-alpaca/internal/discovery"
 )
 
 func TestDiscovery_RespondsWithAlpacaPort(t *testing.T) {

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -7,10 +7,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"sqmeter-alpaca-safetymonitor/internal/config"
-	"sqmeter-alpaca-safetymonitor/internal/safety"
-	"sqmeter-alpaca-safetymonitor/internal/sqmclient"
-	"sqmeter-alpaca-safetymonitor/internal/state"
+	"sqmeter-ascom-alpaca/internal/config"
+	"sqmeter-ascom-alpaca/internal/safety"
+	"sqmeter-ascom-alpaca/internal/sqmclient"
+	"sqmeter-ascom-alpaca/internal/state"
 )
 
 // Poller periodically fetches SQMeter sensor data, evaluates safety rules,

--- a/internal/poller/poller_test.go
+++ b/internal/poller/poller_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"sqmeter-alpaca-safetymonitor/internal/config"
-	"sqmeter-alpaca-safetymonitor/internal/poller"
-	"sqmeter-alpaca-safetymonitor/internal/sqmclient"
-	"sqmeter-alpaca-safetymonitor/internal/state"
+	"sqmeter-ascom-alpaca/internal/config"
+	"sqmeter-ascom-alpaca/internal/poller"
+	"sqmeter-ascom-alpaca/internal/sqmclient"
+	"sqmeter-ascom-alpaca/internal/state"
 )
 
 func silentLogger() *slog.Logger {

--- a/internal/safety/evaluator.go
+++ b/internal/safety/evaluator.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	"sqmeter-alpaca-safetymonitor/internal/config"
-	"sqmeter-alpaca-safetymonitor/internal/sqmclient"
-	"sqmeter-alpaca-safetymonitor/internal/state"
+	"sqmeter-ascom-alpaca/internal/config"
+	"sqmeter-ascom-alpaca/internal/sqmclient"
+	"sqmeter-ascom-alpaca/internal/state"
 )
 
 // Input is everything the evaluator needs to produce a safety decision.

--- a/internal/safety/evaluator_extra_test.go
+++ b/internal/safety/evaluator_extra_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"sqmeter-alpaca-safetymonitor/internal/safety"
+	"sqmeter-ascom-alpaca/internal/safety"
 )
 
 // ---------- fail-open (no data) ----------------------------------------------

--- a/internal/safety/evaluator_test.go
+++ b/internal/safety/evaluator_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"sqmeter-alpaca-safetymonitor/internal/config"
-	"sqmeter-alpaca-safetymonitor/internal/safety"
-	"sqmeter-alpaca-safetymonitor/internal/sqmclient"
+	"sqmeter-ascom-alpaca/internal/config"
+	"sqmeter-ascom-alpaca/internal/safety"
+	"sqmeter-ascom-alpaca/internal/sqmclient"
 )
 
 func defaultCfg() *config.Config {

--- a/internal/sqmclient/client_test.go
+++ b/internal/sqmclient/client_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"sqmeter-alpaca-safetymonitor/internal/sqmclient"
+	"sqmeter-ascom-alpaca/internal/sqmclient"
 )
 
 func newFakeServer(sensors sqmclient.SensorsResponse, status sqmclient.StatusResponse) *httptest.Server {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"time"
 
-	"sqmeter-alpaca-safetymonitor/internal/sqmclient"
+	"sqmeter-ascom-alpaca/internal/sqmclient"
 )
 
 // Values are the sensor readings that informed the safety decision.

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"sqmeter-alpaca-safetymonitor/internal/state"
+	"sqmeter-ascom-alpaca/internal/state"
 )
 
 func TestNewHolder_ConnectedOnStartup(t *testing.T) {

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -11,10 +11,10 @@ import (
 	"strconv"
 	"time"
 
-	"sqmeter-alpaca-safetymonitor/internal/alpaca"
-	"sqmeter-alpaca-safetymonitor/internal/config"
-	"sqmeter-alpaca-safetymonitor/internal/discovery"
-	"sqmeter-alpaca-safetymonitor/internal/state"
+	"sqmeter-ascom-alpaca/internal/alpaca"
+	"sqmeter-ascom-alpaca/internal/config"
+	"sqmeter-ascom-alpaca/internal/discovery"
+	"sqmeter-ascom-alpaca/internal/state"
 )
 
 // Handler serves the local web dashboard, setup page, and utility endpoints.

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -9,10 +9,10 @@ import (
 	"testing"
 	"time"
 
-	"sqmeter-alpaca-safetymonitor/internal/config"
-	"sqmeter-alpaca-safetymonitor/internal/discovery"
-	"sqmeter-alpaca-safetymonitor/internal/state"
-	"sqmeter-alpaca-safetymonitor/internal/web"
+	"sqmeter-ascom-alpaca/internal/config"
+	"sqmeter-ascom-alpaca/internal/discovery"
+	"sqmeter-ascom-alpaca/internal/state"
+	"sqmeter-ascom-alpaca/internal/web"
 )
 
 func newTestWebHandler(t *testing.T, connected bool, ev state.EvaluatedState) (*web.Handler, *config.Holder, *state.Holder) {

--- a/scripts/conform.sh
+++ b/scripts/conform.sh
@@ -13,14 +13,14 @@
 #   CONFORM_BIN   path to the conformu binary (auto-detected)
 #   SQM_PORT      port for the mock SQMeter server  (default: 18080)
 #   ALPACA_PORT   port for the Alpaca service        (default: 11111)
-#   SERVICE_BIN   path to the built service binary   (default: bin/sqmeter-alpaca-safetymonitor)
+#   SERVICE_BIN   path to the built service binary   (default: bin/sqmeter-ascom-alpaca)
 #   LOG_LEVEL     log verbosity for the service       (default: info)
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SQM_PORT="${SQM_PORT:-18080}"
 ALPACA_PORT="${ALPACA_PORT:-11111}"
-SERVICE_BIN="${SERVICE_BIN:-${REPO_ROOT}/bin/sqmeter-alpaca-safetymonitor}"
+SERVICE_BIN="${SERVICE_BIN:-${REPO_ROOT}/bin/sqmeter-ascom-alpaca}"
 IS_MACOS=false
 [[ "$(uname)" == "Darwin" ]] && IS_MACOS=true
 


### PR DESCRIPTION
## Summary
- Renames the Go module, command, binary, installer, and service naming to SQMeter ASCOM Alpaca.
- Updates build/release scripts and documentation.
- Keeps AppData/ProgramData path unchanged pending a dedicated migration.

## Validation
- `go mod tidy`
- `go test ./...`
- `go vet ./...`
- `go build ./cmd/sqmeter-ascom-alpaca`
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -o dist/sqmeter-ascom-alpaca.exe ./cmd/sqmeter-ascom-alpaca`

## Notes
- AppData/ProgramData path migration is intentionally deferred.
- Intentionally retained legacy strings:
  - AppDataDirName = "SQMeter SafetyMonitor" in internal/config/paths.go — ProgramData path unchanged, migration deferred
  - Windows installer AppDataDir = "SQMeter SafetyMonitor" — same reason
  - Alpaca deviceName = "SQMeter SafetyMonitor" and OC device name — Alpaca device identity strings shown to ASCOM clients, intentionally preserved