### PR TITLE
Remove deleted env example from release archives

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -46,7 +46,6 @@ archives:
     files:
       - README.md
       - LICENSE
-      - .env.example
 
   - id: linux
     ids: [linux-amd64, linux-arm64]
@@ -55,7 +54,6 @@ archives:
     files:
       - README.md
       - LICENSE
-      - .env.example
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
## Summary
- Removes the deleted .env.example file from GoReleaser archive contents.
- Fixes the v0.2.0-alpha.2 release workflow failure.

## Validation
- GoReleaser failure was caused by missing .env.example.
- .env.example is intentionally removed because config.json is now the source of truth.

Refs v0.2.0-alpha.2