### PR TITLE
Fix ServeMux route conflict on startup

### DIFF
--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -71,7 +71,7 @@ func New(cfgHolder *config.Holder, holder *state.Holder) (*Handler, error) {
 
 // Register wires web routes onto mux.
 func (h *Handler) Register(mux *http.ServeMux) {
-	mux.HandleFunc("GET /", h.Dashboard)
+	mux.HandleFunc("/", h.Dashboard)
 	mux.HandleFunc("GET /status", h.Dashboard)
 	mux.HandleFunc("GET /health", h.Health)
 	mux.HandleFunc("GET /status.json", h.StatusJSON)
@@ -108,6 +108,19 @@ type DashboardData struct {
 }
 
 func (h *Handler) Dashboard(w http.ResponseWriter, r *http.Request) {
+	// Only serve dashboard at / and /status.
+	if r.URL.Path != "/" && r.URL.Path != "/status" {
+		http.NotFound(w, r)
+		return
+	}
+
+	// Only accept GET and HEAD methods.
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", "GET, HEAD")
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
 	s := h.holder.Get()
 	cfg := h.cfgHolder.Get()
 

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -881,40 +881,35 @@ func TestServiceStop_WithoutCallback_Returns501(t *testing.T) {
 }
 
 func TestServiceRestart_GET_DoesNotTriggerAction(t *testing.T) {
-	// GET /api/service/restart falls through to the Dashboard catch-all ("GET /")
-	// and never calls the service callback. This is the intended safety behaviour:
-	// service actions require an explicit POST.
+	// GET /api/service/restart is not a registered route (only POST is).
+	// It falls through to the /api/ catch-all and returns 404.
+	// This is the intended safety behaviour: service actions require an explicit POST.
 	h, _, _ := newTestWebHandler(t, true, safeEv())
 	triggered := false
 	h.WithServiceControl(func() { triggered = true }, nil)
 
 	w := serve(t, h, http.MethodGet, "/api/service/restart", "")
-	if w.Code != http.StatusOK {
-		t.Errorf("GET /api/service/restart: want 200 (dashboard fallback), got %d", w.Code)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("GET /api/service/restart: want 404, got %d", w.Code)
 	}
 	if triggered {
 		t.Error("GET /api/service/restart: must not trigger restart callback")
 	}
-	// Must not return service-control JSON
-	if strings.Contains(w.Body.String(), `"ok"`) {
-		t.Error("GET /api/service/restart: must not return service-control JSON")
-	}
 }
 
 func TestServiceStop_GET_DoesNotTriggerAction(t *testing.T) {
+	// GET /api/service/stop is not a registered route (only POST is).
+	// It falls through to the /api/ catch-all and returns 404.
 	h, _, _ := newTestWebHandler(t, true, safeEv())
 	triggered := false
 	h.WithServiceControl(nil, func() { triggered = true })
 
 	w := serve(t, h, http.MethodGet, "/api/service/stop", "")
-	if w.Code != http.StatusOK {
-		t.Errorf("GET /api/service/stop: want 200 (dashboard fallback), got %d", w.Code)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("GET /api/service/stop: want 404, got %d", w.Code)
 	}
 	if triggered {
 		t.Error("GET /api/service/stop: must not trigger stop callback")
-	}
-	if strings.Contains(w.Body.String(), `"ok"`) {
-		t.Error("GET /api/service/stop: must not return service-control JSON")
 	}
 }
 
@@ -979,5 +974,47 @@ func TestGetSetup_DisplaysOptionalFloats(t *testing.T) {
 	}
 	if !strings.Contains(body, "2.3") {
 		t.Error("GET /setup: expected DEWPOINT_MARGIN_MIN_C value 2.3 in response")
+	}
+}
+
+// ---------- route conflict prevention tests ---------------------------------
+
+func TestDashboard_GET_RootPath(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	w := serve(t, h, http.MethodGet, "/", "")
+	if w.Code != http.StatusOK {
+		t.Errorf("GET /: want 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "SQMeter") {
+		t.Error("GET /: expected dashboard HTML")
+	}
+}
+
+func TestDashboard_HEAD_RootPath(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	w := serve(t, h, http.MethodHead, "/", "")
+	if w.Code != http.StatusOK {
+		t.Errorf("HEAD /: want 200, got %d", w.Code)
+	}
+}
+
+func TestDashboard_POST_RootPath_MethodNotAllowed(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	w := serve(t, h, http.MethodPost, "/", "")
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("POST /: want 405, got %d", w.Code)
+	}
+	allow := w.Header().Get("Allow")
+	if allow != "GET, HEAD" {
+		t.Errorf("POST /: want Allow: GET, HEAD, got %q", allow)
+	}
+}
+
+func TestDashboard_UnknownPath_NotFound(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	w := serve(t, h, http.MethodGet, "/nonexistent", "")
+	if w.Code != http.StatusNotFound {
+		t.Errorf("GET /nonexistent: want 404, got %d", w.Code)
 	}
 }

--- a/internal/web/routes_integration_test.go
+++ b/internal/web/routes_integration_test.go
@@ -1,0 +1,75 @@
+package web_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"sqmeter-ascom-alpaca/internal/alpaca"
+	"sqmeter-ascom-alpaca/internal/config"
+	"sqmeter-ascom-alpaca/internal/state"
+	"sqmeter-ascom-alpaca/internal/web"
+)
+
+// TestRouteRegistration_NoConflict verifies that web and alpaca handlers can
+// be registered together without ServeMux pattern conflicts (Go 1.23+).
+func TestRouteRegistration_NoConflict(t *testing.T) {
+	cfgHolder := config.NewHolder(config.Defaults(), "")
+	holder := state.NewHolder(true)
+
+	webHandler, err := web.New(cfgHolder, holder)
+	if err != nil {
+		t.Fatalf("web.New: %v", err)
+	}
+
+	alpacaHandler := alpaca.New(cfgHolder, holder, "test-uuid", "v0.0.0-test", nil)
+
+	// Register both handlers (this would panic on Go 1.23 if routes conflict)
+	mux := http.NewServeMux()
+	alpacaHandler.Register(mux)
+	webHandler.Register(mux)
+
+	// Test GET / returns dashboard HTML
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("GET /: want 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "SQMeter") {
+		t.Error("GET /: expected dashboard HTML")
+	}
+
+	// Test unknown /api/ path returns JSON 404, not HTML
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/badpath", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("GET /api/v1/badpath: want 404, got %d", w.Code)
+	}
+	body = w.Body.String()
+	if strings.Contains(body, "<html") || strings.Contains(body, "SQMeter") {
+		t.Error("GET /api/v1/badpath: should return JSON, not HTML dashboard")
+	}
+	if !strings.Contains(body, "not found") {
+		t.Error("GET /api/v1/badpath: expected 'not found' in JSON response")
+	}
+
+	// Test valid Alpaca endpoint still works
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/safetymonitor/0/description", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("GET /api/v1/safetymonitor/0/description: want 200, got %d", w.Code)
+	}
+
+	// Test unknown web path returns 404
+	req = httptest.NewRequest(http.MethodGet, "/nonexistent", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("GET /nonexistent: want 404, got %d", w.Code)
+	}
+}


### PR DESCRIPTION
Fixes runtime panic caused by conflicting net/http ServeMux patterns in Go 1.23+.

## Problem
The v0.2.0-alpha.2 Windows binary panics on startup with:
```
pattern "GET /" conflicts with pattern "/api/":
GET / matches fewer methods than /api/, but has a more general path pattern
```

This occurs because:
- `GET /` is method-specific (GET only) but path-general (matches all paths under /)
- `/api/` is method-general (all methods) but path-specific
- Go 1.23's ServeMux rejects this pattern combination

## Solution
Changed web Dashboard handler registration from `GET /` to `/` and added method/path checking inside the handler:

- Registers `/` without method restriction
- Handler checks method (GET/HEAD only) and returns 405 for others
- Handler checks path (`/` and `/status` only) and returns 404 for others
- Unknown `/api/` paths return JSON 404 (not HTML dashboard)

## Changes
- **internal/web/handlers.go**: Updated `Register()` and `Dashboard()` handler
- **internal/web/handlers_test.go**: Added tests for new behavior, updated service control tests
- **internal/web/routes_integration_test.go**: New integration test verifying web + alpaca handlers register without conflict

## Testing
- ✅ All existing tests pass
- ✅ New tests cover GET, HEAD, POST, and 404 behavior
- ✅ Integration test verifies no ServeMux conflicts
- ✅ `go vet ./...` passes
- ✅ Binary builds and starts without panic
- ✅ ConformU bad-path tests still pass (malformed /api/ paths return JSON 404)

## Validation
```bash
go test ./internal/web ./internal/alpaca
go test ./...
go vet ./...
go build ./cmd/sqmeter-ascom-alpaca
./sqmeter-ascom-alpaca  # Confirms no panic on startup
```