### PR TITLE
Redesign ASCOM SQMeter Bridge web UI

### DIFF
--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -71,7 +71,11 @@ func New(cfgHolder *config.Holder, holder *state.Holder) (*Handler, error) {
 
 // Register wires web routes onto mux.
 func (h *Handler) Register(mux *http.ServeMux) {
-	mux.HandleFunc("GET /", h.Dashboard)
+	// Use method-agnostic "/" so that alpaca's "/api/" catch-all (which is also
+	// method-agnostic) can take precedence without a Go 1.22 pattern conflict.
+	// Method-qualified "/api/service/*" and "/api/diagnostics" patterns remain
+	// more specific and still resolve correctly.
+	mux.HandleFunc("/", h.Dashboard)
 	mux.HandleFunc("GET /status", h.Dashboard)
 	mux.HandleFunc("GET /health", h.Health)
 	mux.HandleFunc("GET /status.json", h.StatusJSON)
@@ -86,6 +90,24 @@ func (h *Handler) Register(mux *http.ServeMux) {
 }
 
 // ---------- dashboard --------------------------------------------------------
+
+// OCProperty is a row in the Observing Conditions table.
+type OCProperty struct {
+	AlpacaName string
+	Source     string
+	Value      string // formatted value, or "—" if unavailable
+	Unit       string
+	Status     string // "available", "missing", "unsupported"
+}
+
+// SafetyRule is a row in the Safety Monitor rules table.
+type SafetyRule struct {
+	Name      string
+	Threshold string
+	Current   string // formatted current value, or "—"
+	Result    string // "pass", "fail", "warn", "n/a"
+	Enabled   bool
+}
 
 type DashboardData struct {
 	SQMeterURL            string
@@ -105,9 +127,27 @@ type DashboardData struct {
 	DiscoveryError        string
 	DiscoveryHasStats     bool // true when we have a status getter
 	ServiceControlEnabled bool // true when restart/stop callbacks are wired
+
+	// Extended fields for the redesigned dashboard
+	Version               string
+	HTTPBind              string
+	Config                *config.Config
+	RawPayload            string // JSON-serialised last SQMeter payload, or ""
+	DataAge               string // human-readable age of last successful poll
+	OCProps               []OCProperty
+	SafetyRules           []SafetyRule
+	SQMMinSafeStr         string // optional float, pre-formatted for template
+	HumidityMaxSafeStr    string
+	DewpointMarginMinCStr string
 }
 
 func (h *Handler) Dashboard(w http.ResponseWriter, r *http.Request) {
+	// "/" is a catch-all; only serve dashboard for known web UI paths.
+	if r.URL.Path != "/" && r.URL.Path != "/status" {
+		http.NotFound(w, r)
+		return
+	}
+
 	s := h.holder.Get()
 	cfg := h.cfgHolder.Get()
 
@@ -118,6 +158,18 @@ func (h *Handler) Dashboard(w http.ResponseWriter, r *http.Request) {
 	lastSuccess := "—"
 	if !s.LastSuccessfulPollUTC.IsZero() {
 		lastSuccess = s.LastSuccessfulPollUTC.UTC().Format("2006-01-02 15:04:05 UTC")
+	}
+
+	dataAge := "—"
+	if !s.LastSuccessfulPollUTC.IsZero() {
+		dataAge = time.Since(s.LastSuccessfulPollUTC).Round(time.Second).String()
+	}
+
+	rawPayload := ""
+	if s.RawSensors != nil {
+		if b, err := json.MarshalIndent(s.RawSensors, "", "  "); err == nil {
+			rawPayload = string(b)
+		}
 	}
 
 	data := DashboardData{
@@ -133,6 +185,23 @@ func (h *Handler) Dashboard(w http.ResponseWriter, r *http.Request) {
 		HasData:       !s.LastSuccessfulPollUTC.IsZero(),
 		DewMargin:     s.Values.Temperature - s.Values.Dewpoint,
 		WideOpen:      config.IsWideOpen(cfg.AlpacaHTTPBind),
+
+		Version:     h.version,
+		HTTPBind:    cfg.AlpacaHTTPBind,
+		Config:      cfg,
+		RawPayload:  rawPayload,
+		DataAge:     dataAge,
+		OCProps:     buildOCProperties(s),
+		SafetyRules: buildSafetyRules(cfg, s),
+	}
+	if cfg.SQMMinSafe != nil {
+		data.SQMMinSafeStr = fmt.Sprintf("%.2f", *cfg.SQMMinSafe)
+	}
+	if cfg.HumidityMaxSafe != nil {
+		data.HumidityMaxSafeStr = fmt.Sprintf("%.1f", *cfg.HumidityMaxSafe)
+	}
+	if cfg.DewpointMarginMinC != nil {
+		data.DewpointMarginMinCStr = fmt.Sprintf("%.1f", *cfg.DewpointMarginMinC)
 	}
 	if h.discoveryStatus != nil {
 		ds := h.discoveryStatus()
@@ -146,6 +215,195 @@ func (h *Handler) Dashboard(w http.ResponseWriter, r *http.Request) {
 	if err := h.dash.Execute(w, data); err != nil {
 		http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
 	}
+}
+
+// buildOCProperties constructs the Observing Conditions property table rows from
+// the current evaluated state. Availability reflects sensor health at the time of
+// the last poll.
+func buildOCProperties(s state.EvaluatedState) []OCProperty {
+	raw := s.RawSensors
+	haIR := raw != nil && raw.IRTemperature.Status == 0
+	haEnv := raw != nil && raw.Environment.Status == 0
+	haLight := raw != nil && raw.LightSensor.Status == 0
+
+	av := func(name, src, val, unit string) OCProperty {
+		return OCProperty{AlpacaName: name, Source: src, Value: val, Unit: unit, Status: "available"}
+	}
+	ms := func(name, src, unit string) OCProperty {
+		return OCProperty{AlpacaName: name, Source: src, Value: "—", Unit: unit, Status: "missing"}
+	}
+	un := func(name string) OCProperty {
+		return OCProperty{AlpacaName: name, Source: "n/a", Value: "—", Unit: "—", Status: "unsupported"}
+	}
+
+	props := make([]OCProperty, 0, 13)
+
+	if haIR {
+		props = append(props, av("CloudCover", "cloudConditions.cloudCoverPercent", fmt.Sprintf("%.1f", s.Values.CloudCoverPercent), "%"))
+	} else {
+		props = append(props, ms("CloudCover", "cloudConditions.cloudCoverPercent", "%"))
+	}
+	if haEnv {
+		props = append(props, av("DewPoint", "environment.dewpoint", fmt.Sprintf("%.1f", s.Values.Dewpoint), "°C"))
+	} else {
+		props = append(props, ms("DewPoint", "environment.dewpoint", "°C"))
+	}
+	if haEnv {
+		props = append(props, av("Humidity", "environment.humidity", fmt.Sprintf("%.1f", s.Values.Humidity), "%"))
+	} else {
+		props = append(props, ms("Humidity", "environment.humidity", "%"))
+	}
+	if haEnv {
+		props = append(props, av("Pressure", "environment.pressure", fmt.Sprintf("%.1f", raw.Environment.Pressure), "hPa"))
+	} else {
+		props = append(props, ms("Pressure", "environment.pressure", "hPa"))
+	}
+	props = append(props, un("RainRate"))
+	if haLight {
+		props = append(props, av("SkyBrightness", "lightSensor.lux", fmt.Sprintf("%.1f", raw.LightSensor.Lux), "lux"))
+	} else {
+		props = append(props, ms("SkyBrightness", "lightSensor.lux", "lux"))
+	}
+	if haLight {
+		props = append(props, av("SkyQuality", "lightSensor.sqm", fmt.Sprintf("%.2f", s.Values.SQM), "mag/arcsec²"))
+	} else {
+		props = append(props, ms("SkyQuality", "lightSensor.sqm", "mag/arcsec²"))
+	}
+	if haIR {
+		props = append(props, av("SkyTemperature", "irTemperature.objectTemp", fmt.Sprintf("%.1f", raw.IRTemperature.ObjectTemp), "°C"))
+	} else {
+		props = append(props, ms("SkyTemperature", "irTemperature.objectTemp", "°C"))
+	}
+	props = append(props, un("StarFWHM"))
+	if haEnv {
+		props = append(props, av("Temperature", "environment.temperature", fmt.Sprintf("%.1f", s.Values.Temperature), "°C"))
+	} else {
+		props = append(props, ms("Temperature", "environment.temperature", "°C"))
+	}
+	props = append(props, un("WindDirection"))
+	props = append(props, un("WindGust"))
+	props = append(props, un("WindSpeed"))
+	return props
+}
+
+// buildSafetyRules constructs the safety rules table from config and current state.
+func buildSafetyRules(cfg *config.Config, s state.EvaluatedState) []SafetyRule {
+	raw := s.RawSensors
+	haIR := raw != nil && raw.IRTemperature.Status == 0
+	haEnv := raw != nil && raw.Environment.Status == 0
+	haLight := raw != nil && raw.LightSensor.Status == 0
+
+	rules := make([]SafetyRule, 0, 8)
+
+	// Cloud cover — unsafe threshold
+	ccCurrent := "—"
+	ccUnsafeResult := "n/a"
+	ccWarnResult := "n/a"
+	if haIR {
+		ccCurrent = fmt.Sprintf("%.1f%%", s.Values.CloudCoverPercent)
+		if s.Values.CloudCoverPercent >= cfg.CloudCoverUnsafePct {
+			ccUnsafeResult = "fail"
+		} else {
+			ccUnsafeResult = "pass"
+		}
+		if s.Values.CloudCoverPercent >= cfg.CloudCoverCautionPct {
+			ccWarnResult = "warn"
+		} else {
+			ccWarnResult = "pass"
+		}
+	}
+	rules = append(rules, SafetyRule{
+		Name:      "Cloud cover below unsafe threshold",
+		Threshold: fmt.Sprintf("< %.0f%%", cfg.CloudCoverUnsafePct),
+		Current:   ccCurrent,
+		Result:    ccUnsafeResult,
+		Enabled:   true,
+	})
+	rules = append(rules, SafetyRule{
+		Name:      "Cloud cover below caution threshold",
+		Threshold: fmt.Sprintf("< %.0f%%", cfg.CloudCoverCautionPct),
+		Current:   ccCurrent,
+		Result:    ccWarnResult,
+		Enabled:   true,
+	})
+
+	// Sensor status rules
+	hasAnyData := raw != nil
+	sensorRule := func(name string, statusOK bool, enabled bool) SafetyRule {
+		current, result := "—", "n/a"
+		if hasAnyData {
+			if statusOK {
+				current, result = "OK", "pass"
+			} else {
+				current, result = "error", "fail"
+			}
+		}
+		return SafetyRule{Name: name, Threshold: "status = 0", Current: current, Result: result, Enabled: enabled}
+	}
+	lightOK := raw != nil && raw.LightSensor.Status == 0
+	envOK := raw != nil && raw.Environment.Status == 0
+	irOK := raw != nil && raw.IRTemperature.Status == 0
+	rules = append(rules, sensorRule("Light sensor status OK", lightOK, cfg.RequireLightStatus))
+	rules = append(rules, sensorRule("Environment sensor status OK", envOK, cfg.RequireEnvStatus))
+	rules = append(rules, sensorRule("IR temperature sensor status OK", irOK, cfg.RequireIRStatus))
+
+	// Optional hard limits
+	if cfg.SQMMinSafe != nil {
+		current, result := "—", "n/a"
+		if haLight {
+			current = fmt.Sprintf("%.2f", s.Values.SQM)
+			if s.Values.SQM < *cfg.SQMMinSafe {
+				result = "fail"
+			} else {
+				result = "pass"
+			}
+		}
+		rules = append(rules, SafetyRule{
+			Name:      "SQM above minimum",
+			Threshold: fmt.Sprintf(">= %.2f mag/arcsec²", *cfg.SQMMinSafe),
+			Current:   current,
+			Result:    result,
+			Enabled:   true,
+		})
+	}
+	if cfg.HumidityMaxSafe != nil {
+		current, result := "—", "n/a"
+		if haEnv {
+			current = fmt.Sprintf("%.1f%%", s.Values.Humidity)
+			if s.Values.Humidity > *cfg.HumidityMaxSafe {
+				result = "fail"
+			} else {
+				result = "pass"
+			}
+		}
+		rules = append(rules, SafetyRule{
+			Name:      "Humidity below maximum",
+			Threshold: fmt.Sprintf("<= %.1f%%", *cfg.HumidityMaxSafe),
+			Current:   current,
+			Result:    result,
+			Enabled:   true,
+		})
+	}
+	if cfg.DewpointMarginMinC != nil {
+		current, result := "—", "n/a"
+		if haEnv {
+			margin := s.Values.Temperature - s.Values.Dewpoint
+			current = fmt.Sprintf("%.1f°C", margin)
+			if margin < *cfg.DewpointMarginMinC {
+				result = "fail"
+			} else {
+				result = "pass"
+			}
+		}
+		rules = append(rules, SafetyRule{
+			Name:      "Dew point margin adequate",
+			Threshold: fmt.Sprintf(">= %.1f°C", *cfg.DewpointMarginMinC),
+			Current:   current,
+			Result:    result,
+			Enabled:   true,
+		})
+	}
+	return rules
 }
 
 // ---------- health / status.json ---------------------------------------------

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -881,16 +881,15 @@ func TestServiceStop_WithoutCallback_Returns501(t *testing.T) {
 }
 
 func TestServiceRestart_GET_DoesNotTriggerAction(t *testing.T) {
-	// GET /api/service/restart falls through to the Dashboard catch-all ("GET /")
-	// and never calls the service callback. This is the intended safety behaviour:
-	// service actions require an explicit POST.
+	// GET /api/service/restart is not a known web UI path and returns 404.
+	// It must never call the service callback — service actions require an explicit POST.
 	h, _, _ := newTestWebHandler(t, true, safeEv())
 	triggered := false
 	h.WithServiceControl(func() { triggered = true }, nil)
 
 	w := serve(t, h, http.MethodGet, "/api/service/restart", "")
-	if w.Code != http.StatusOK {
-		t.Errorf("GET /api/service/restart: want 200 (dashboard fallback), got %d", w.Code)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("GET /api/service/restart: want 404, got %d", w.Code)
 	}
 	if triggered {
 		t.Error("GET /api/service/restart: must not trigger restart callback")
@@ -907,8 +906,8 @@ func TestServiceStop_GET_DoesNotTriggerAction(t *testing.T) {
 	h.WithServiceControl(nil, func() { triggered = true })
 
 	w := serve(t, h, http.MethodGet, "/api/service/stop", "")
-	if w.Code != http.StatusOK {
-		t.Errorf("GET /api/service/stop: want 200 (dashboard fallback), got %d", w.Code)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("GET /api/service/stop: want 404, got %d", w.Code)
 	}
 	if triggered {
 		t.Error("GET /api/service/stop: must not trigger stop callback")
@@ -979,5 +978,69 @@ func TestGetSetup_DisplaysOptionalFloats(t *testing.T) {
 	}
 	if !strings.Contains(body, "2.3") {
 		t.Error("GET /setup: expected DEWPOINT_MARGIN_MIN_C value 2.3 in response")
+	}
+}
+
+// ---------- redesigned dashboard branding and structure ----------------------
+
+func TestDashboard_IncludesASCOMSQMeterBridgeBranding(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	w := serve(t, h, http.MethodGet, "/", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("dashboard: want 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "ASCOM SQMeter Bridge") {
+		t.Error("dashboard: expected 'ASCOM SQMeter Bridge' branding")
+	}
+}
+
+func TestDashboard_IncludesSafetyMonitorSection(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	w := serve(t, h, http.MethodGet, "/", "")
+	body := w.Body.String()
+	if !strings.Contains(body, "Safety Monitor") {
+		t.Error("dashboard: expected 'Safety Monitor' section")
+	}
+	if !strings.Contains(body, "SafetyMonitor/0") {
+		t.Error("dashboard: expected 'SafetyMonitor/0' device listed")
+	}
+}
+
+func TestDashboard_IncludesObservingConditionsSection(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	w := serve(t, h, http.MethodGet, "/", "")
+	body := w.Body.String()
+	if !strings.Contains(body, "Observing Conditions") {
+		t.Error("dashboard: expected 'Observing Conditions' section")
+	}
+	if !strings.Contains(body, "ObservingConditions/0") {
+		t.Error("dashboard: expected 'ObservingConditions/0' device listed")
+	}
+}
+
+func TestDashboard_NetworkExposureWarning_WhenWideOpen(t *testing.T) {
+	h, cfgHolder, _ := newTestWebHandler(t, true, safeEv())
+	cfg := *cfgHolder.Get()
+	cfg.AlpacaHTTPBind = "0.0.0.0"
+	cfgHolder.Update(&cfg) //nolint:errcheck
+
+	w := serve(t, h, http.MethodGet, "/", "")
+	body := w.Body.String()
+	if !strings.Contains(body, "0.0.0.0") {
+		t.Error("dashboard: expected bind address 0.0.0.0 in network warning")
+	}
+	if !strings.Contains(body, "reachable from the network") {
+		t.Error("dashboard: expected network exposure warning text")
+	}
+}
+
+func TestDashboard_NoNetworkWarning_WhenLoopback(t *testing.T) {
+	h, _, _ := newTestWebHandler(t, true, safeEv())
+	// default bind is 127.0.0.1
+	w := serve(t, h, http.MethodGet, "/", "")
+	body := w.Body.String()
+	if strings.Contains(body, "reachable from the network") {
+		t.Error("dashboard: must not show network warning for 127.0.0.1 bind")
 	}
 }

--- a/internal/web/routes_integration_test.go
+++ b/internal/web/routes_integration_test.go
@@ -1,0 +1,74 @@
+package web_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"sqmeter-ascom-alpaca/internal/alpaca"
+	"sqmeter-ascom-alpaca/internal/config"
+	"sqmeter-ascom-alpaca/internal/state"
+	"sqmeter-ascom-alpaca/internal/web"
+)
+
+// TestRouteRegistration_NoConflict verifies that web and alpaca handlers can
+// be registered together without ServeMux pattern conflicts (Go 1.23+).
+func TestRouteRegistration_NoConflict(t *testing.T) {
+	cfgHolder := config.NewHolder(config.Defaults(), "")
+	holder := state.NewHolder(true)
+
+	webHandler, err := web.New(cfgHolder, holder)
+	if err != nil {
+		t.Fatalf("web.New: %v", err)
+	}
+
+	alpacaHandler := alpaca.New(cfgHolder, holder, "test-uuid", "v0.0.0-test", nil)
+
+	mux := http.NewServeMux()
+	alpacaHandler.Register(mux)
+	webHandler.Register(mux)
+
+	// GET / returns dashboard HTML with correct branding
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("GET /: want 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "ASCOM SQMeter Bridge") {
+		t.Error("GET /: expected ASCOM SQMeter Bridge branding in dashboard HTML")
+	}
+
+	// Unknown /api/ path returns JSON 404, not dashboard HTML
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/badpath", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("GET /api/v1/badpath: want 404, got %d", w.Code)
+	}
+	body = w.Body.String()
+	if strings.Contains(body, "<html") || strings.Contains(body, "ASCOM SQMeter Bridge") {
+		t.Error("GET /api/v1/badpath: must not return HTML dashboard")
+	}
+	if !strings.Contains(body, "not found") {
+		t.Error("GET /api/v1/badpath: expected 'not found' in JSON response")
+	}
+
+	// Valid Alpaca endpoint still works
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/safetymonitor/0/description", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("GET /api/v1/safetymonitor/0/description: want 200, got %d", w.Code)
+	}
+
+	// Unknown web path returns 404
+	req = httptest.NewRequest(http.MethodGet, "/nonexistent", nil)
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("GET /nonexistent: want 404, got %d", w.Code)
+	}
+}

--- a/internal/web/templates/dashboard.html
+++ b/internal/web/templates/dashboard.html
@@ -1099,7 +1099,11 @@ td.disabled { color: var(--muted); font-style: italic; }
               {{if eq .Result "pass"}}✓ pass{{else if eq .Result "fail"}}✗ fail{{else if eq .Result "warn"}}⚠ caution{{else}}— n/a{{end}}
             </span>
           </td>
-          <td {{if not .Enabled}}class="disabled"{{end}}>{{if .Enabled}}yes{{else}}no (disabled){{end}}</td>
+          <td {{if not .Enabled}}class="disabled"{{end}}>
+            <span class="pill {{if .Enabled}}pill-ok{{else}}pill-muted{{end}}">
+              {{if .Enabled}}enabled{{else}}disabled{{end}}
+            </span>
+          </td>
         </tr>
         {{end}}
       </tbody>

--- a/internal/web/templates/dashboard.html
+++ b/internal/web/templates/dashboard.html
@@ -3,342 +3,1425 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta http-equiv="refresh" content="10">
-<title>SQMeter ASCOM Alpaca</title>
+<meta http-equiv="refresh" content="30">
+<title>ASCOM SQMeter Bridge</title>
 <style>
-  :root {
-    --safe-bg:    #0a3d1f;
-    --safe-fg:    #2ecc71;
-    --unsafe-bg:  #3d0a0a;
-    --unsafe-fg:  #e74c3c;
-    --warn-fg:    #f39c12;
-    --panel-bg:   #1a1a2e;
-    --card-bg:    #16213e;
-    --border:     #0f3460;
-    --text:       #e0e0e0;
-    --muted:      #8892a4;
-    --mono:       'Courier New', monospace;
-  }
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body {
-    background: #0d0d1a;
-    color: var(--text);
-    font-family: 'Segoe UI', system-ui, sans-serif;
-    font-size: 14px;
-    line-height: 1.5;
-    padding: 16px;
-  }
-  header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: 20px;
-    border-bottom: 1px solid var(--border);
-    padding-bottom: 12px;
-  }
-  header h1 { font-size: 1.2rem; color: var(--text); font-weight: 600; }
-  header small { color: var(--muted); font-size: 0.75rem; }
+:root {
+  --bg:          #0d0d1a;
+  --sidebar-bg:  #0f0f22;
+  --card-bg:     #14192e;
+  --card2-bg:    #111826;
+  --border:      #1e2d4a;
+  --border-mid:  #263550;
+  --text:        #dde3ed;
+  --muted:       #6b7a94;
+  --accent:      #4a9eff;
+  --accent-dim:  #2a5a99;
+  --safe:        #2ecc71;
+  --safe-bg:     rgba(46,204,113,0.07);
+  --safe-border: rgba(46,204,113,0.3);
+  --unsafe:      #e74c3c;
+  --unsafe-bg:   rgba(231,76,60,0.07);
+  --unsafe-border:rgba(231,76,60,0.3);
+  --warn:        #f6c768;
+  --warn-bg:     rgba(246,199,104,0.08);
+  --warn-border: rgba(246,199,104,0.35);
+  --danger:      #e74c3c;
+  --mono:        'Courier New', 'Consolas', monospace;
+  --sidebar-w:   210px;
+}
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { height: 100%; }
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+  font-size: 13px;
+  line-height: 1.5;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
 
-  .state-banner {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 16px;
-    border-radius: 10px;
-    padding: 24px 32px;
-    margin-bottom: 20px;
-    border: 2px solid;
-  }
-  .state-banner.safe   { background: var(--safe-bg);   border-color: var(--safe-fg);   }
-  .state-banner.unsafe { background: var(--unsafe-bg);  border-color: var(--unsafe-fg); }
-  .state-label {
-    font-size: 3rem;
-    font-weight: 800;
-    letter-spacing: 4px;
-  }
-  .safe   .state-label { color: var(--safe-fg);   }
-  .unsafe .state-label { color: var(--unsafe-fg); }
-  .state-meta { color: var(--muted); font-size: 0.8rem; line-height: 1.8; }
+/* ---------- Banners ------------------------------------------------- */
+.banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 16px;
+  font-size: 0.82rem;
+  font-weight: 500;
+}
+.banner.warn {
+  background: var(--warn-bg);
+  border-bottom: 1px solid var(--warn-border);
+  color: var(--warn);
+}
+.banner.danger {
+  background: var(--unsafe-bg);
+  border-bottom: 1px solid var(--unsafe-border);
+  color: var(--unsafe);
+}
+.banner a { color: inherit; text-decoration: underline; margin-left: 6px; }
 
-  .override-warn {
-    background: #3d2800;
-    border: 1px solid var(--warn-fg);
-    border-radius: 6px;
-    color: var(--warn-fg);
-    padding: 10px 16px;
-    margin-bottom: 16px;
-    font-weight: 600;
-    text-align: center;
-  }
+/* ---------- Header -------------------------------------------------- */
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--sidebar-bg);
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.header-title h1 {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--text);
+  letter-spacing: -0.01em;
+}
+.header-title .sub {
+  font-size: 0.75rem;
+  color: var(--muted);
+  font-family: var(--mono);
+}
+.header-pills {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 0.72rem;
+  font-family: var(--mono);
+  border: 1px solid;
+  white-space: nowrap;
+}
+.pill-ok    { color: var(--safe);   border-color: var(--safe-border);   background: var(--safe-bg);   }
+.pill-err   { color: var(--unsafe); border-color: var(--unsafe-border); background: var(--unsafe-bg); }
+.pill-warn  { color: var(--warn);   border-color: var(--warn-border);   background: var(--warn-bg);   }
+.pill-muted { color: var(--muted);  border-color: var(--border);        background: transparent;      }
+.dot { font-size: 0.6rem; }
+.version-tag { font-size: 0.7rem; color: var(--muted); font-family: var(--mono); }
 
-  .grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-    gap: 16px;
-    margin-bottom: 20px;
-  }
-  .card {
-    background: var(--card-bg);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    padding: 16px;
-  }
-  .card h2 {
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    letter-spacing: 1px;
-    color: var(--muted);
-    margin-bottom: 12px;
-    border-bottom: 1px solid var(--border);
-    padding-bottom: 6px;
-  }
-  .kv { display: flex; justify-content: space-between; padding: 3px 0; }
-  .kv .k { color: var(--muted); }
-  .kv .v { font-family: var(--mono); font-weight: 600; }
-  .kv .v.ok   { color: var(--safe-fg); }
-  .kv .v.err  { color: var(--unsafe-fg); }
-  .kv .v.warn { color: var(--warn-fg); }
+/* ---------- Layout -------------------------------------------------- */
+.layout {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
 
-  .reasons, .warnings {
-    margin-top: 4px;
-    padding: 0;
-    list-style: none;
-  }
-  .reasons li  { color: var(--unsafe-fg); padding: 2px 0; }
-  .reasons li::before  { content: "✗ "; }
-  .warnings li { color: var(--warn-fg);   padding: 2px 0; }
-  .warnings li::before { content: "⚠ "; }
+/* ---------- Sidebar ------------------------------------------------- */
+.sidebar {
+  width: var(--sidebar-w);
+  flex-shrink: 0;
+  background: var(--sidebar-bg);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  padding: 12px 0 0;
+}
+.sidebar-safety {
+  margin: 0 10px 10px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  border: 1px solid;
+}
+.sidebar-safety.safe   { background: var(--safe-bg);   border-color: var(--safe-border);   }
+.sidebar-safety.unsafe { background: var(--unsafe-bg); border-color: var(--unsafe-border); }
+.safety-state {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 700;
+  font-size: 0.8rem;
+  letter-spacing: 0.05em;
+}
+.safe   .safety-state { color: var(--safe);   }
+.unsafe .safety-state { color: var(--unsafe); }
+.safety-dot { font-size: 0.55rem; }
+.sidebar-meta-line {
+  font-size: 0.68rem;
+  color: var(--muted);
+  margin-top: 3px;
+  font-family: var(--mono);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.override-pill {
+  display: inline-block;
+  margin-top: 4px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-size: 0.65rem;
+  font-family: var(--mono);
+  background: var(--warn-bg);
+  border: 1px solid var(--warn-border);
+  color: var(--warn);
+}
 
-  .links {
-    border-top: 1px solid var(--border);
-    padding-top: 12px;
-    margin-top: 4px;
-    font-size: 0.8rem;
-    color: var(--muted);
-  }
-  .links a { color: #5b9bd5; text-decoration: none; margin-right: 12px; }
-  .links a:hover { text-decoration: underline; }
+.sidebar-sqm {
+  margin: 0 10px 10px;
+  padding: 6px 10px;
+  border-radius: 5px;
+  background: var(--card2-bg);
+  border: 1px solid var(--border);
+}
+.sqm-status {
+  font-size: 0.75rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+.sqm-status.ok   { color: var(--safe);   }
+.sqm-status.err  { color: var(--unsafe); }
 
-  .svc-controls { display: flex; gap: 8px; margin-top: 10px; flex-wrap: wrap; }
-  .btn {
-    padding: 6px 14px;
-    border: none;
-    border-radius: 5px;
-    font-size: 0.8rem;
-    font-weight: 600;
-    cursor: pointer;
-    letter-spacing: 0.4px;
-  }
-  .btn-warn   { background: #7a4a00; color: #f39c12; border: 1px solid #f39c12; }
-  .btn-warn:hover   { background: #9a5e00; }
-  .btn-danger { background: #5a0a0a; color: #e74c3c; border: 1px solid #e74c3c; }
-  .btn-danger:hover { background: #7a1010; }
-  #svc-msg { margin-top: 8px; font-size: 0.8rem; display: none; }
+.sidebar-divider {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 2px 10px 8px;
+}
 
-  footer {
-    margin-top: 20px;
-    border-top: 1px solid var(--border);
-    padding-top: 10px;
-    font-size: 0.75rem;
-    color: var(--muted);
-  }
+/* Navigation */
+nav { padding: 0 6px; flex: 1; }
+.nav-item {
+  display: block;
+  padding: 7px 10px;
+  border-radius: 5px;
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 0.82rem;
+  margin-bottom: 1px;
+  transition: background 0.1s, color 0.1s;
+  cursor: pointer;
+}
+.nav-item:hover { background: var(--card-bg); color: var(--text); }
+.nav-item.active { background: var(--accent-dim); color: #fff; font-weight: 600; }
+
+.sidebar-footer {
+  padding: 10px 10px 12px;
+  border-top: 1px solid var(--border);
+  margin-top: auto;
+}
+.sidebar-footer a {
+  display: block;
+  font-size: 0.68rem;
+  font-family: var(--mono);
+  color: var(--muted);
+  text-decoration: none;
+  padding: 2px 0;
+}
+.sidebar-footer a:hover { color: var(--accent); }
+
+/* ---------- Content ------------------------------------------------- */
+.content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+}
+.page { display: none; }
+.page.active { display: block; }
+
+/* ---------- Section header ------------------------------------------ */
+.section-title {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 1.2px;
+  color: var(--muted);
+  margin-bottom: 12px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+  font-weight: 600;
+}
+
+/* ---------- Cards --------------------------------------------------- */
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  padding: 14px;
+  margin-bottom: 14px;
+}
+.card-title {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--muted);
+  margin-bottom: 10px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+  font-weight: 600;
+}
+
+/* ---------- Tiles --------------------------------------------------- */
+.tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 10px;
+  margin-bottom: 14px;
+}
+.tile {
+  background: var(--card2-bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 12px;
+}
+.tile-label {
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: var(--muted);
+  margin-bottom: 5px;
+}
+.tile-val {
+  font-size: 0.8rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+.tile-val.ok   { color: var(--safe);   }
+.tile-val.err  { color: var(--unsafe); }
+.tile-val.warn { color: var(--warn);   }
+.tile-val.muted { color: var(--muted); }
+.tile-sub { font-size: 0.65rem; color: var(--muted); margin-top: 3px; font-family: var(--mono); }
+
+/* ---------- Key-value rows ------------------------------------------ */
+.kv-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+}
+.kv {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 3px 0;
+  gap: 8px;
+}
+.kv .k { color: var(--muted); font-size: 0.78rem; flex-shrink: 0; }
+.kv .v { font-family: var(--mono); font-size: 0.78rem; font-weight: 600; text-align: right; word-break: break-all; }
+.kv .v.ok   { color: var(--safe);   }
+.kv .v.err  { color: var(--unsafe); }
+.kv .v.warn { color: var(--warn);   }
+
+/* ---------- Tables -------------------------------------------------- */
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.78rem;
+}
+.data-table th {
+  text-align: left;
+  padding: 6px 10px;
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: var(--muted);
+  border-bottom: 1px solid var(--border);
+  font-weight: 600;
+}
+.data-table td {
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: middle;
+}
+.data-table tr:last-child td { border-bottom: none; }
+.data-table tr:hover td { background: rgba(255,255,255,0.02); }
+.data-table td.mono { font-family: var(--mono); }
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 7px;
+  border-radius: 3px;
+  font-size: 0.68rem;
+  font-weight: 600;
+  font-family: var(--mono);
+}
+.status-badge.available  { color: var(--safe);   background: var(--safe-bg);   border: 1px solid var(--safe-border);   }
+.status-badge.missing    { color: var(--muted);  background: transparent;      border: 1px solid var(--border);        }
+.status-badge.unsupported { color: var(--muted); background: transparent;      border: 1px dashed var(--border);       }
+td.muted { color: var(--muted); }
+
+/* ---------- Filters ------------------------------------------------- */
+.filter-bar {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+.filter-btn {
+  padding: 4px 12px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--muted);
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+.filter-btn.active { background: var(--accent-dim); border-color: var(--accent); color: #fff; }
+.filter-btn:hover:not(.active) { border-color: var(--border-mid); color: var(--text); }
+
+/* ---------- Rule table result badges -------------------------------- */
+.result-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 7px;
+  border-radius: 3px;
+  font-size: 0.68rem;
+  font-weight: 600;
+  font-family: var(--mono);
+}
+.result-badge.pass     { color: var(--safe);   background: var(--safe-bg);   border: 1px solid var(--safe-border);   }
+.result-badge.fail     { color: var(--unsafe); background: var(--unsafe-bg); border: 1px solid var(--unsafe-border); }
+.result-badge.warn     { color: var(--warn);   background: var(--warn-bg);   border: 1px solid var(--warn-border);   }
+.result-badge.na       { color: var(--muted);  background: transparent;      border: 1px solid var(--border);        }
+td.disabled { color: var(--muted); font-style: italic; }
+
+/* ---------- Config form -------------------------------------------- */
+.form-section {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  padding: 14px;
+  margin-bottom: 12px;
+}
+.form-section-title {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--muted);
+  margin-bottom: 12px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+  font-weight: 600;
+}
+.field { margin-bottom: 10px; }
+.field:last-child { margin-bottom: 0; }
+.field label {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--muted);
+  margin-bottom: 4px;
+}
+.field label .restart-tag {
+  color: var(--warn);
+  font-size: 0.65rem;
+  margin-left: 6px;
+}
+.field label .danger-tag {
+  color: var(--danger);
+  font-size: 0.65rem;
+  margin-left: 6px;
+}
+.field input[type=text],
+.field input[type=number],
+.field select {
+  width: 100%;
+  background: #0a1020;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text);
+  padding: 5px 9px;
+  font-size: 0.82rem;
+  font-family: var(--mono);
+}
+.field input:focus, .field select:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+.field .hint { font-size: 0.68rem; color: var(--muted); margin-top: 3px; }
+.readonly-val {
+  background: #0a1020;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--muted);
+  padding: 5px 9px;
+  font-size: 0.82rem;
+  font-family: var(--mono);
+  cursor: default;
+}
+.grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+.checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  font-size: 0.82rem;
+}
+.checkbox-row:last-child { margin-bottom: 0; }
+.checkbox-row input[type=checkbox] { accent-color: var(--accent); width: 14px; height: 14px; flex-shrink: 0; }
+.form-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 4px;
+  flex-wrap: wrap;
+}
+.wide-open-field {
+  border-color: var(--warn-border) !important;
+}
+
+/* ---------- Buttons ------------------------------------------------- */
+.btn {
+  padding: 6px 16px;
+  border-radius: 5px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid;
+  transition: background 0.1s;
+}
+.btn-primary { background: var(--accent-dim); border-color: var(--accent); color: #fff; }
+.btn-primary:hover { background: #3570b0; }
+.btn-secondary { background: transparent; border-color: var(--border-mid); color: var(--muted); }
+.btn-secondary:hover { border-color: var(--accent); color: var(--accent); }
+.btn-warn   { background: rgba(246,199,104,0.08); border-color: var(--warn); color: var(--warn); }
+.btn-warn:hover { background: rgba(246,199,104,0.15); }
+.btn-danger { background: var(--unsafe-bg); border-color: var(--unsafe); color: var(--unsafe); }
+.btn-danger:hover { background: rgba(231,76,60,0.15); }
+.btn-copy {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--muted);
+  padding: 2px 7px;
+  border-radius: 3px;
+  font-size: 0.65rem;
+  cursor: pointer;
+  font-family: var(--mono);
+}
+.btn-copy:hover { border-color: var(--accent); color: var(--accent); }
+.btn-test {
+  background: transparent;
+  border: 1px solid var(--accent-dim);
+  color: var(--accent);
+  padding: 4px 12px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  margin-top: 6px;
+}
+.btn-test:hover { background: rgba(74,158,255,0.1); }
+.test-result { font-size: 0.72rem; font-family: var(--mono); margin-top: 4px; min-height: 1.2em; }
+.test-result.ok  { color: var(--safe);   }
+.test-result.err { color: var(--unsafe); }
+
+/* ---------- Config feedback ---------------------------------------- */
+#cfg-feedback { font-size: 0.78rem; margin-left: 2px; }
+#cfg-feedback.ok   { color: var(--safe);   }
+#cfg-feedback.err  { color: var(--unsafe); }
+#cfg-feedback.warn { color: var(--warn);   }
+.restart-notice {
+  background: var(--warn-bg);
+  border: 1px solid var(--warn-border);
+  border-radius: 5px;
+  padding: 7px 12px;
+  font-size: 0.75rem;
+  color: var(--warn);
+  margin-top: 8px;
+  display: none;
+}
+
+/* ---------- Diagnostics sub-tabs ----------------------------------- */
+.tab-bar {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 14px;
+}
+.tab-btn {
+  padding: 6px 14px;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--muted);
+  font-size: 0.8rem;
+  cursor: pointer;
+  margin-bottom: -1px;
+}
+.tab-btn.active { color: var(--accent); border-bottom-color: var(--accent); font-weight: 600; }
+.tab-btn:hover:not(.active) { color: var(--text); }
+.tab-panel { display: none; }
+.tab-panel.active { display: block; }
+
+/* ---------- Code / raw payload ------------------------------------- */
+.code-block {
+  background: #080c18;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 10px 12px;
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  color: #b0c0d8;
+  overflow-x: auto;
+  white-space: pre;
+  max-height: 420px;
+  overflow-y: auto;
+}
+.not-available {
+  color: var(--muted);
+  font-size: 0.78rem;
+  padding: 12px 0;
+}
+
+/* ---------- Endpoint list ------------------------------------------ */
+.endpoint-list { display: flex; flex-direction: column; gap: 3px; }
+.endpoint-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 8px;
+  border-radius: 4px;
+  background: var(--card2-bg);
+}
+.endpoint-row:hover { background: #1a2540; }
+.ep-path {
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  color: var(--accent);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ep-path a { color: inherit; text-decoration: none; }
+.ep-path a:hover { text-decoration: underline; }
+.ep-desc { font-size: 0.7rem; color: var(--muted); flex-shrink: 0; }
+
+/* ---------- Reasons / warnings lists ------------------------------- */
+.reasons-list, .warnings-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.reasons-list li  { color: var(--unsafe); padding: 2px 0; font-size: 0.8rem; }
+.reasons-list li::before  { content: "✗ "; }
+.warnings-list li { color: var(--warn);   padding: 2px 0; font-size: 0.8rem; }
+.warnings-list li::before { content: "⚠ "; }
+
+/* ---------- Service controls --------------------------------------- */
+.svc-controls { display: flex; gap: 8px; margin-top: 8px; flex-wrap: wrap; }
+#svc-msg { margin-top: 6px; font-size: 0.78rem; display: none; }
+
+/* ---------- Safety state card -------------------------------------- */
+.safety-state-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 7px;
+  border: 1px solid;
+  margin-bottom: 14px;
+}
+.safety-state-card.safe   { background: var(--safe-bg);   border-color: var(--safe-border);   }
+.safety-state-card.unsafe { background: var(--unsafe-bg); border-color: var(--unsafe-border); }
+.safety-label-text {
+  font-size: 1.15rem;
+  font-weight: 800;
+  letter-spacing: 3px;
+}
+.safe   .safety-label-text { color: var(--safe);   }
+.unsafe .safety-label-text { color: var(--unsafe); }
+.safety-card-meta { font-size: 0.75rem; color: var(--muted); line-height: 1.8; }
 </style>
 </head>
 <body>
 
-<header>
-  <div>
-    <h1>SQMeter ASCOM Alpaca</h1>
-    <small>ASCOM Alpaca bridge &nbsp;·&nbsp; port {{.HTTPPort}} &nbsp;·&nbsp; uptime {{.Uptime}}</small>
-  </div>
-  <div style="text-align:right">
-    <small>SQMeter: <code>{{.SQMeterURL}}</code></small><br>
-    <small>Discovery UDP: {{.DiscoveryPort}}{{if .DiscoveryHasStats}}{{if .DiscoveryRunning}} <span style="color:#2ecc71">&#x25cf; running</span>{{else}} <span style="color:#e74c3c">&#x25cf; not running</span>{{end}}{{end}}</small>
-  </div>
-</header>
-
 {{if .WideOpen}}
-<div class="override-warn" style="background:#2d1500;border-color:#f39c12;color:#f39c12;">
-  ⚠ Service is reachable from the network. Do not expose this port to the internet.
-  <a href="/setup" style="color:#f39c12;margin-left:8px; font-weight:normal;">[Setup]</a>
+<div class="banner warn">
+  <span>⚠</span>
+  <span>
+    Service is reachable from the network (ALPACA_HTTP_BIND={{.HTTPBind}}).
+    Do not expose this port to the internet.
+    <a href="#" onclick="showPage('configuration');return false;">Configure</a>
+  </span>
 </div>
 {{end}}
 {{if eq .Override "force_safe"}}
-<div class="override-warn">⚠ MANUAL OVERRIDE: force_safe — safety rules are bypassed
-  <a href="/setup" style="color:var(--warn-fg);margin-left:8px;font-weight:normal;">[Setup]</a>
+<div class="banner warn">
+  <span>⚠</span>
+  <span>MANUAL OVERRIDE: force_safe — safety rules are bypassed.
+    <a href="#" onclick="showPage('configuration');return false;">Configure</a></span>
 </div>
 {{end}}
 {{if eq .Override "force_unsafe"}}
-<div class="override-warn">⛔ MANUAL OVERRIDE: force_unsafe — always reporting UNSAFE
-  <a href="/setup" style="color:var(--warn-fg);margin-left:8px;font-weight:normal;">[Setup]</a>
+<div class="banner danger">
+  <span>⛔</span>
+  <span>MANUAL OVERRIDE: force_unsafe — always reporting UNSAFE.
+    <a href="#" onclick="showPage('configuration');return false;">Configure</a></span>
 </div>
 {{end}}
 {{if and .DiscoveryHasStats (not .DiscoveryHealthy)}}
-<div class="override-warn" style="background:#3d0a0a;border-color:#e74c3c;color:#e74c3c;">
-  ✗ Alpaca UDP discovery is not running — N.I.N.A. auto-discovery will not work.{{if .DiscoveryError}} Error: {{.DiscoveryError}}{{end}}
-  <a href="/setup" style="color:#e74c3c;margin-left:8px;font-weight:normal;">[Setup]</a>
+<div class="banner danger">
+  <span>✗</span>
+  <span>Alpaca UDP discovery is not running — N.I.N.A. auto-discovery will not work.{{if .DiscoveryError}} Error: {{.DiscoveryError}}{{end}}</span>
 </div>
 {{end}}
 
-<div class="state-banner {{if .State.IsSafe}}safe{{else}}unsafe{{end}}">
-  <div class="state-label">{{if .State.IsSafe}}SAFE{{else}}UNSAFE{{end}}</div>
-  <div class="state-meta">
-    Connected: {{if .Connected}}yes{{else}}no{{end}}<br>
-    Last poll: {{.LastPoll}}<br>
-    Last success: {{.LastSuccess}}
+<header>
+  <div class="header-title">
+    <h1>ASCOM SQMeter Bridge</h1>
+    <div class="sub">Alpaca bridge &nbsp;·&nbsp; port {{.HTTPPort}} &nbsp;·&nbsp; up {{.Uptime}}</div>
   </div>
-</div>
-
-{{if .State.Reasons}}
-<div class="card" style="margin-bottom:16px; border-color: #e74c3c55;">
-  <h2>Unsafe reasons</h2>
-  <ul class="reasons">
-    {{range .State.Reasons}}<li>{{.}}</li>{{end}}
-  </ul>
-</div>
-{{end}}
-
-{{if .State.Warnings}}
-<div class="card" style="margin-bottom:16px; border-color: #f39c1255;">
-  <h2>Warnings / cautions</h2>
-  <ul class="warnings">
-    {{range .State.Warnings}}<li>{{.}}</li>{{end}}
-  </ul>
-</div>
-{{end}}
-
-<div class="grid">
-
-  <div class="card">
-    <h2>Sky Quality</h2>
-    {{if .HasData}}
-    <div class="kv"><span class="k">SQM</span>
-      <span class="v">{{printf "%.2f" .State.Values.SQM}} mag/arcsec²</span></div>
-    <div class="kv"><span class="k">Bortle</span>
-      <span class="v">{{printf "%.1f" .State.Values.Bortle}}</span></div>
-    {{else}}
-    <div class="kv"><span class="k">—</span><span class="v err">no data</span></div>
-    {{end}}
-  </div>
-
-  <div class="card">
-    <h2>Cloud Cover</h2>
-    {{if .HasData}}
-    <div class="kv"><span class="k">Cover</span>
-      <span class="v {{if ge .State.Values.CloudCoverPercent 80.0}}err{{else if ge .State.Values.CloudCoverPercent 50.0}}warn{{else}}ok{{end}}">
-        {{printf "%.1f" .State.Values.CloudCoverPercent}}%
-      </span></div>
-    <div class="kv"><span class="k">Condition</span>
-      <span class="v">{{.State.Values.CloudCondition}}</span></div>
-    <div class="kv"><span class="k">IR delta</span>
-      <span class="v">{{printf "%.1f" .State.Values.TemperatureDelta}}°C</span></div>
-    <div class="kv"><span class="k">Corrected delta</span>
-      <span class="v">{{printf "%.1f" .State.Values.CorrectedDelta}}°C</span></div>
-    {{else}}
-    <div class="kv"><span class="k">—</span><span class="v err">no data</span></div>
-    {{end}}
-  </div>
-
-  <div class="card">
-    <h2>Environment</h2>
-    {{if .HasData}}
-    <div class="kv"><span class="k">Temperature</span>
-      <span class="v">{{printf "%.1f" .State.Values.Temperature}}°C</span></div>
-    <div class="kv"><span class="k">Humidity</span>
-      <span class="v">{{printf "%.1f" .State.Values.Humidity}}%</span></div>
-    <div class="kv"><span class="k">Dew point</span>
-      <span class="v">{{printf "%.1f" .State.Values.Dewpoint}}°C</span></div>
-    <div class="kv"><span class="k">Dew margin</span>
-      <span class="v {{if lt .DewMargin 3.0}}warn{{else}}ok{{end}}">
-        {{printf "%.1f" .DewMargin}}°C
-      </span></div>
-    {{else}}
-    <div class="kv"><span class="k">—</span><span class="v err">no data</span></div>
-    {{end}}
-  </div>
-
-  <div class="card">
-    <h2>Status</h2>
-    <div class="kv"><span class="k">Connected</span>
-      <span class="v {{if .Connected}}ok{{else}}err{{end}}">{{if .Connected}}yes{{else}}no{{end}}</span></div>
-    <div class="kv"><span class="k">Override</span>
-      <span class="v {{if ne .Override "auto"}}warn{{end}}">{{.Override}}</span></div>
-    <div class="kv"><span class="k">Has data</span>
-      <span class="v {{if .HasData}}ok{{else}}err{{end}}">{{if .HasData}}yes{{else}}no{{end}}</span></div>
+  <div class="header-pills">
+    <span class="pill {{if .Connected}}pill-ok{{else}}pill-err{{end}}">
+      <span class="dot">{{if .Connected}}●{{else}}●{{end}}</span>
+      SQMeter {{.SQMeterURL}}
+    </span>
     {{if .DiscoveryHasStats}}
-    <div class="kv"><span class="k">Discovery UDP</span>
-      <span class="v {{if .DiscoveryRunning}}ok{{else}}err{{end}}">{{if .DiscoveryRunning}}running{{else}}not running{{end}}</span></div>
+    <span class="pill {{if .DiscoveryRunning}}pill-ok{{else}}pill-err{{end}}">
+      <span class="dot">{{if .DiscoveryRunning}}●{{else}}●{{end}}</span>
+      Discovery :{{.DiscoveryPort}}{{if not .DiscoveryRunning}} not running{{end}}
+    </span>
+    {{else}}
+    <span class="pill pill-muted">Discovery :{{.DiscoveryPort}}</span>
     {{end}}
+    {{if .Version}}<span class="version-tag">{{.Version}}</span>{{end}}
+  </div>
+</header>
+
+<div class="layout">
+
+<aside class="sidebar">
+  <div class="sidebar-safety {{if .State.IsSafe}}safe{{else}}unsafe{{end}}">
+    <div class="safety-state">
+      <span class="safety-dot">{{if .State.IsSafe}}●{{else}}●{{end}}</span>
+      {{if .State.IsSafe}}SAFE{{else}}UNSAFE{{end}}
+    </div>
+    {{if ne .Override "auto"}}
+    <span class="override-pill">override: {{.Override}}</span>
+    {{end}}
+    <div class="sidebar-meta-line">eval: {{.LastPoll}}</div>
+  </div>
+
+  <div class="sidebar-sqm">
+    <div class="sqm-status {{if .Connected}}ok{{else}}err{{end}}">
+      <span>{{if .Connected}}●{{else}}●{{end}}</span>
+      <span>{{if .Connected}}SQMeter connected{{else}}SQMeter disconnected{{end}}</span>
+    </div>
+    <div class="sidebar-meta-line">age: {{.DataAge}}</div>
+  </div>
+
+  <hr class="sidebar-divider">
+
+  <nav>
+    <a href="#" data-page="overview"              class="nav-item active">Overview</a>
+    <a href="#" data-page="configuration"         class="nav-item">Configuration</a>
+    <a href="#" data-page="safety"                class="nav-item">Safety Monitor</a>
+    <a href="#" data-page="observing-conditions"  class="nav-item">Observing Conditions</a>
+    <a href="#" data-page="diagnostics"           class="nav-item">Diagnostics</a>
+  </nav>
+
+  <div class="sidebar-footer">
+    <a href="/management/apiversions">/management/apiversions</a>
+    <a href="/management/v1/configureddevices">/configureddevices</a>
+    <a href="/api/v1/safetymonitor/0/issafe">/safetymonitor/issafe</a>
+    <a href="/status.json">/status.json</a>
+    <a href="/health">/health</a>
+    <a href="/setup">/setup</a>
+  </div>
+</aside>
+
+<main class="content">
+
+<!-- ===================== OVERVIEW ===================== -->
+<div id="pg-overview" class="page active">
+  <div class="section-title">Overview</div>
+
+  <div class="tiles">
+    <div class="tile">
+      <div class="tile-label">Bridge</div>
+      <div class="tile-val ok">● Running</div>
+      <div class="tile-sub">up {{.Uptime}}</div>
+    </div>
+    <div class="tile">
+      <div class="tile-label">SQMeter</div>
+      <div class="tile-val {{if .Connected}}ok{{else}}err{{end}}">
+        {{if .Connected}}● Connected{{else}}● Disconnected{{end}}
+      </div>
+      <div class="tile-sub">age: {{.DataAge}}</div>
+    </div>
+    {{if .DiscoveryHasStats}}
+    <div class="tile">
+      <div class="tile-label">Discovery</div>
+      <div class="tile-val {{if .DiscoveryRunning}}ok{{else}}err{{end}}">
+        {{if .DiscoveryRunning}}● Running{{else}}● not running{{end}}
+      </div>
+      <div class="tile-sub">UDP :{{.DiscoveryPort}}</div>
+    </div>
+    {{else}}
+    <div class="tile">
+      <div class="tile-label">Discovery</div>
+      <div class="tile-val muted">— Unknown</div>
+      <div class="tile-sub">UDP :{{.DiscoveryPort}}</div>
+    </div>
+    {{end}}
+    <div class="tile">
+      <div class="tile-label">Devices</div>
+      <div class="tile-val ok">● 2 devices</div>
+      <div class="tile-sub">SM/0 · OC/0</div>
+    </div>
+    <div class="tile">
+      <div class="tile-label">Safety Monitor</div>
+      <div class="tile-val {{if .State.IsSafe}}ok{{else}}err{{end}}">
+        {{if .State.IsSafe}}● SAFE{{else}}● UNSAFE{{end}}
+      </div>
+      {{if .State.Reasons}}
+      <div class="tile-sub" style="color:var(--unsafe); white-space:normal; line-height:1.3;">
+        {{index .State.Reasons 0}}
+      </div>
+      {{end}}
+    </div>
+  </div>
+
+  <!-- Current Readings -->
+  <div class="card">
+    <div class="card-title">Current Readings</div>
+    {{if .HasData}}
+    <div class="kv-grid">
+      <div>
+        <div class="kv"><span class="k">SQM</span><span class="v">{{printf "%.2f" .State.Values.SQM}} mag/arcsec²</span></div>
+        <div class="kv"><span class="k">Bortle</span><span class="v">{{printf "%.1f" .State.Values.Bortle}}</span></div>
+        <div class="kv"><span class="k">Cloud cover</span><span class="v {{if ge .State.Values.CloudCoverPercent .Config.CloudCoverUnsafePct}}err{{else if ge .State.Values.CloudCoverPercent .Config.CloudCoverCautionPct}}warn{{else}}ok{{end}}">{{printf "%.1f" .State.Values.CloudCoverPercent}}%</span></div>
+        <div class="kv"><span class="k">Cloud condition</span><span class="v">{{.State.Values.CloudCondition}}</span></div>
+        <div class="kv"><span class="k">IR delta</span><span class="v">{{printf "%.1f" .State.Values.TemperatureDelta}}°C</span></div>
+      </div>
+      <div>
+        <div class="kv"><span class="k">Temperature</span><span class="v">{{printf "%.1f" .State.Values.Temperature}}°C</span></div>
+        <div class="kv"><span class="k">Humidity</span><span class="v">{{printf "%.1f" .State.Values.Humidity}}%</span></div>
+        <div class="kv"><span class="k">Dew point</span><span class="v">{{printf "%.1f" .State.Values.Dewpoint}}°C</span></div>
+        <div class="kv"><span class="k">Dew margin</span><span class="v {{if lt .DewMargin 3.0}}warn{{else}}ok{{end}}">{{printf "%.1f" .DewMargin}}°C</span></div>
+      </div>
+    </div>
+    {{else}}
+    <div class="not-available">No sensor data available yet.</div>
+    {{end}}
+  </div>
+
+  <!-- Bridge Status -->
+  <div class="card">
+    <div class="card-title">Bridge Status</div>
+    <div class="kv-grid">
+      <div>
+        <div class="kv"><span class="k">Version</span><span class="v">{{if .Version}}{{.Version}}{{else}}—{{end}}</span></div>
+        <div class="kv"><span class="k">Bind</span><span class="v {{if .WideOpen}}warn{{end}}">{{.HTTPBind}}:{{.HTTPPort}}</span></div>
+        <div class="kv"><span class="k">SQMeter URL</span><span class="v">{{.SQMeterURL}}</span></div>
+        <div class="kv"><span class="k">Override</span><span class="v {{if ne .Override "auto"}}warn{{end}}">{{.Override}}</span></div>
+      </div>
+      <div>
+        <div class="kv"><span class="k">Poll interval</span><span class="v">{{.Config.PollIntervalSeconds}}s</span></div>
+        <div class="kv"><span class="k">Stale after</span><span class="v">{{.Config.StaleAfterSeconds}}s</span></div>
+        <div class="kv"><span class="k">Fail-closed</span><span class="v">{{if .Config.FailClosed}}yes{{else}}no{{end}}</span></div>
+        <div class="kv"><span class="k">Connected</span><span class="v {{if .Connected}}ok{{else}}err{{end}}">{{if .Connected}}yes{{else}}no{{end}}</span></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Poll Timing -->
+  <div class="card">
+    <div class="card-title">Poll Timing</div>
+    <div class="kv"><span class="k">Last poll</span><span class="v">{{.LastPoll}}</span></div>
+    <div class="kv"><span class="k">Last success</span><span class="v">{{.LastSuccess}}</span></div>
+    <div class="kv"><span class="k">Data age</span><span class="v">{{.DataAge}}</span></div>
     {{if .State.LastError}}
-    <div class="kv"><span class="k">Last error</span>
-      <span class="v err" style="font-size:0.75rem; max-width:180px; word-break:break-all;">{{.State.LastError}}</span></div>
-    {{end}}
-    {{if and .DiscoveryHasStats .DiscoveryError}}
-    <div class="kv"><span class="k">Discovery error</span>
-      <span class="v err" style="font-size:0.75rem; max-width:180px; word-break:break-all;">{{.DiscoveryError}}</span></div>
+    <div class="kv"><span class="k">Last error</span><span class="v err" style="font-size:0.72rem;max-width:280px;word-break:break-all;">{{.State.LastError}}</span></div>
     {{end}}
   </div>
 
-</div>
+  <!-- Exposed Alpaca Devices -->
+  <div class="card">
+    <div class="card-title">Exposed Alpaca Devices</div>
+    <div style="display:flex;flex-direction:column;gap:6px;">
+      <div style="display:flex;align-items:center;gap:10px;padding:6px 0;border-bottom:1px solid var(--border);">
+        <span class="status-badge available">ObservingConditions/0</span>
+        <span style="font-size:0.78rem;color:var(--muted);">SQMeter ObservingConditions</span>
+        <a href="/api/v1/observingconditions/0/cloudcover" style="font-size:0.7rem;font-family:var(--mono);color:var(--accent);margin-left:auto;text-decoration:none;">/cloudcover</a>
+      </div>
+      <div style="display:flex;align-items:center;gap:10px;padding:6px 0;">
+        <span class="status-badge available">SafetyMonitor/0</span>
+        <span style="font-size:0.78rem;color:var(--muted);">SQMeter SafetyMonitor</span>
+        <a href="/api/v1/safetymonitor/0/issafe" style="font-size:0.7rem;font-family:var(--mono);color:var(--accent);margin-left:auto;text-decoration:none;">/issafe</a>
+      </div>
+    </div>
+  </div>
 
-{{if .ServiceControlEnabled}}
-<div class="card" style="margin-bottom:16px;" id="service-controls">
-  <h2>Service Controls</h2>
-  {{if .WideOpen}}
-  <p style="color:var(--warn-fg);font-size:0.8rem;margin-bottom:6px;">
-    ⚠ Service is reachable from the network — these controls affect all connected clients.
-  </p>
+  {{if .ServiceControlEnabled}}
+  <div class="card" id="service-controls">
+    <div class="card-title">Service Controls</div>
+    {{if .WideOpen}}
+    <p style="color:var(--warn);font-size:0.75rem;margin-bottom:6px;">
+      ⚠ Service is reachable from the network — these controls affect all connected clients.
+    </p>
+    {{end}}
+    <p style="color:var(--muted);font-size:0.75rem;margin-bottom:4px;">
+      Restart exits and relies on the service manager to restart automatically.<br>
+      Stop ends the process — N.I.N.A./Alpaca integration is unavailable until the service is restarted.
+    </p>
+    <div class="svc-controls">
+      <button class="btn btn-warn" onclick="svcAction('restart')">Restart service</button>
+      <button class="btn btn-danger" onclick="svcAction('stop')">Stop service</button>
+    </div>
+    <div id="svc-msg"></div>
+  </div>
   {{end}}
-  <p style="color:var(--muted);font-size:0.8rem;margin-bottom:2px;">
-    Restart exits and relies on the service manager to restart automatically.<br>
-    Stop ends the process — N.I.N.A./Alpaca integration is unavailable until the service is restarted.
-  </p>
-  <div class="svc-controls">
-    <button class="btn btn-warn" onclick="svcAction('restart')">Restart service</button>
-    <button class="btn btn-danger" onclick="svcAction('stop')">Stop service</button>
+
+</div><!-- /overview -->
+
+<!-- ===================== CONFIGURATION ===================== -->
+<div id="pg-configuration" class="page">
+  <div class="section-title">Configuration</div>
+
+  {{if .WideOpen}}
+  <div class="banner warn" style="border-radius:6px;margin-bottom:12px;border:1px solid var(--warn-border);">
+    <span>⚠</span>
+    <span>Service is reachable from the network (ALPACA_HTTP_BIND={{.HTTPBind}}). Binding to 0.0.0.0 exposes Alpaca and service controls to the local network.</span>
   </div>
-  <div id="svc-msg"></div>
-</div>
+  {{end}}
+
+  <div class="form-section">
+    <div class="form-section-title">SQMeter Connection</div>
+    <div class="field">
+      <label>SQMETER_BASE_URL</label>
+      <input type="text" id="cfg-SQMETER_BASE_URL" name="SQMETER_BASE_URL" value="{{.Config.SQMeterBaseURL}}" placeholder="http://192.168.1.100">
+      <div class="hint">Base URL of your SQMeter device. Applied immediately after save.</div>
+      <button type="button" class="btn-test" onclick="testSQMeter()">Test connection</button>
+      <div id="cfg-test-result" class="test-result"></div>
+    </div>
+  </div>
+
+  <div class="form-section">
+    <div class="form-section-title">HTTP Bind &amp; Alpaca Discovery
+      <span style="color:var(--warn);font-size:0.65rem;font-weight:normal;margin-left:6px;">(changes require restart)</span>
+    </div>
+    <div class="grid2">
+      <div class="field">
+        <label>ALPACA_HTTP_BIND <span class="restart-tag">restart required</span> <span class="danger-tag">⚠ use 127.0.0.1 for local-only</span></label>
+        <input type="text" id="cfg-ALPACA_HTTP_BIND" name="ALPACA_HTTP_BIND" value="{{.Config.AlpacaHTTPBind}}" placeholder="127.0.0.1" class="{{if .WideOpen}}wide-open-field{{end}}">
+        <div class="hint">127.0.0.1 = local only · 0.0.0.0 = network accessible (not recommended)</div>
+      </div>
+      <div class="field">
+        <label>ALPACA_HTTP_PORT <span class="restart-tag">restart required</span></label>
+        <input type="number" id="cfg-ALPACA_HTTP_PORT" name="ALPACA_HTTP_PORT" value="{{.Config.AlpacaHTTPPort}}" min="1" max="65535">
+      </div>
+      <div class="field">
+        <label>ALPACA_DISCOVERY_PORT <span class="restart-tag">restart required</span></label>
+        <input type="number" id="cfg-ALPACA_DISCOVERY_PORT" name="ALPACA_DISCOVERY_PORT" value="{{.Config.AlpacaDiscoveryPort}}" min="1" max="65535">
+        <div class="hint">UDP port for ASCOM Alpaca auto-discovery.</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="form-section">
+    <div class="form-section-title">Polling</div>
+    <div class="grid2">
+      <div class="field">
+        <label>POLL_INTERVAL_SECONDS</label>
+        <input type="number" id="cfg-POLL_INTERVAL_SECONDS" name="POLL_INTERVAL_SECONDS" value="{{.Config.PollIntervalSeconds}}" min="1" max="3600">
+        <div class="hint">How often to poll the SQMeter. Applied immediately.</div>
+      </div>
+      <div class="field">
+        <label>STALE_AFTER_SECONDS</label>
+        <input type="number" id="cfg-STALE_AFTER_SECONDS" name="STALE_AFTER_SECONDS" value="{{.Config.StaleAfterSeconds}}" min="1" max="86400">
+        <div class="hint">Report unsafe if data older than this. Applied immediately.</div>
+      </div>
+    </div>
+    <div class="checkbox-row">
+      <input type="checkbox" id="cfg-FAIL_CLOSED" name="FAIL_CLOSED" {{if .Config.FailClosed}}checked{{end}}>
+      <label for="cfg-FAIL_CLOSED">FAIL_CLOSED — report UNSAFE when SQMeter is unreachable or data is stale</label>
+    </div>
+    <div class="checkbox-row">
+      <input type="checkbox" id="cfg-CONNECTED_ON_STARTUP" name="CONNECTED_ON_STARTUP" {{if .Config.ConnectedOnStartup}}checked{{end}}>
+      <label for="cfg-CONNECTED_ON_STARTUP">CONNECTED_ON_STARTUP — start in connected state on next launch</label>
+    </div>
+  </div>
+
+  <div class="form-section">
+    <div class="form-section-title">Safety Thresholds</div>
+    <div class="grid2">
+      <div class="field">
+        <label>CLOUD_COVER_UNSAFE_PERCENT</label>
+        <input type="number" id="cfg-CLOUD_COVER_UNSAFE_PERCENT" name="CLOUD_COVER_UNSAFE_PERCENT" value="{{printf "%.1f" .Config.CloudCoverUnsafePct}}" min="0" max="100" step="0.1">
+        <div class="hint">Cloud cover % that triggers UNSAFE.</div>
+      </div>
+      <div class="field">
+        <label>CLOUD_COVER_CAUTION_PERCENT</label>
+        <input type="number" id="cfg-CLOUD_COVER_CAUTION_PERCENT" name="CLOUD_COVER_CAUTION_PERCENT" value="{{printf "%.1f" .Config.CloudCoverCautionPct}}" min="0" max="100" step="0.1">
+        <div class="hint">Cloud cover % that triggers a caution warning.</div>
+      </div>
+      <div class="field">
+        <label>SQM_MIN_SAFE (mag/arcsec²)</label>
+        <input type="number" id="cfg-SQM_MIN_SAFE" name="SQM_MIN_SAFE" value="{{.SQMMinSafeStr}}" step="0.01" placeholder="disabled">
+        <div class="hint">Unsafe if SQM drops below this. Leave blank to disable.</div>
+      </div>
+      <div class="field">
+        <label>HUMIDITY_MAX_SAFE (%)</label>
+        <input type="number" id="cfg-HUMIDITY_MAX_SAFE" name="HUMIDITY_MAX_SAFE" value="{{.HumidityMaxSafeStr}}" step="0.1" placeholder="disabled">
+        <div class="hint">Unsafe if humidity exceeds this. Leave blank to disable.</div>
+      </div>
+      <div class="field">
+        <label>DEWPOINT_MARGIN_MIN_C (°C)</label>
+        <input type="number" id="cfg-DEWPOINT_MARGIN_MIN_C" name="DEWPOINT_MARGIN_MIN_C" value="{{.DewpointMarginMinCStr}}" step="0.1" placeholder="disabled">
+        <div class="hint">Unsafe if (temperature − dew point) &lt; this. Leave blank to disable.</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="form-section">
+    <div class="form-section-title">Sensor Health Requirements</div>
+    <p style="font-size:0.72rem;color:var(--muted);margin-bottom:10px;">When checked, a non-zero sensor status code causes UNSAFE. Applied immediately.</p>
+    <div class="checkbox-row">
+      <input type="checkbox" id="cfg-REQUIRE_LIGHT_SENSOR_STATUS_OK" name="REQUIRE_LIGHT_SENSOR_STATUS_OK" {{if .Config.RequireLightStatus}}checked{{end}}>
+      <label for="cfg-REQUIRE_LIGHT_SENSOR_STATUS_OK">REQUIRE_LIGHT_SENSOR_STATUS_OK</label>
+    </div>
+    <div class="checkbox-row">
+      <input type="checkbox" id="cfg-REQUIRE_ENVIRONMENT_STATUS_OK" name="REQUIRE_ENVIRONMENT_STATUS_OK" {{if .Config.RequireEnvStatus}}checked{{end}}>
+      <label for="cfg-REQUIRE_ENVIRONMENT_STATUS_OK">REQUIRE_ENVIRONMENT_STATUS_OK</label>
+    </div>
+    <div class="checkbox-row">
+      <input type="checkbox" id="cfg-REQUIRE_IR_TEMPERATURE_STATUS_OK" name="REQUIRE_IR_TEMPERATURE_STATUS_OK" {{if .Config.RequireIRStatus}}checked{{end}}>
+      <label for="cfg-REQUIRE_IR_TEMPERATURE_STATUS_OK">REQUIRE_IR_TEMPERATURE_STATUS_OK</label>
+    </div>
+  </div>
+
+  <div class="form-section">
+    <div class="form-section-title">Override &amp; Logging</div>
+    <div class="grid2">
+      <div class="field">
+        <label>MANUAL_OVERRIDE</label>
+        <select id="cfg-MANUAL_OVERRIDE" name="MANUAL_OVERRIDE">
+          <option value="auto"         {{if eq .Config.ManualOverride "auto"}}selected{{end}}>auto (use safety rules)</option>
+          <option value="force_safe"   {{if eq .Config.ManualOverride "force_safe"}}selected{{end}}>force_safe (BYPASS RULES)</option>
+          <option value="force_unsafe" {{if eq .Config.ManualOverride "force_unsafe"}}selected{{end}}>force_unsafe (always UNSAFE)</option>
+        </select>
+        <div class="hint">Applied immediately. force_safe bypasses all safety rules.</div>
+      </div>
+      <div class="field">
+        <label>LOG_LEVEL</label>
+        <select id="cfg-LOG_LEVEL" name="LOG_LEVEL">
+          <option value="debug" {{if eq .Config.LogLevel "debug"}}selected{{end}}>debug</option>
+          <option value="info"  {{if eq .Config.LogLevel "info"}}selected{{end}}>info</option>
+          <option value="warn"  {{if eq .Config.LogLevel "warn"}}selected{{end}}>warn</option>
+          <option value="error" {{if eq .Config.LogLevel "error"}}selected{{end}}>error</option>
+        </select>
+      </div>
+    </div>
+  </div>
+
+  <div class="form-section">
+    <div class="form-section-title">Device Names <span style="color:var(--muted);font-size:0.65rem;font-weight:normal;margin-left:6px;">(read-only — not configurable at runtime)</span></div>
+    <div class="grid2">
+      <div class="field">
+        <label>SafetyMonitor device name</label>
+        <div class="readonly-val">SQMeter SafetyMonitor</div>
+      </div>
+      <div class="field">
+        <label>ObservingConditions device name</label>
+        <div class="readonly-val">SQMeter ObservingConditions</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="form-actions">
+    <button class="btn btn-primary" onclick="saveConfig()">Save &amp; apply</button>
+    <span id="cfg-feedback"></span>
+  </div>
+  <div id="cfg-restart-notice" class="restart-notice">
+    ⚠ Saved — restart required for: <span id="cfg-restart-fields"></span>
+  </div>
+
+</div><!-- /configuration -->
+
+<!-- ===================== SAFETY MONITOR ===================== -->
+<div id="pg-safety" class="page">
+  <div class="section-title">Safety Monitor</div>
+
+  <div class="safety-state-card {{if .State.IsSafe}}safe{{else}}unsafe{{end}}">
+    <div class="safety-label-text">{{if .State.IsSafe}}SAFE{{else}}UNSAFE{{end}}</div>
+    <div class="safety-card-meta">
+      Connected: {{if .Connected}}yes{{else}}no{{end}}<br>
+      Override: {{.Override}}<br>
+      Fail-closed: {{if .Config.FailClosed}}yes{{else}}no{{end}}<br>
+      Evaluated: {{.LastPoll}}
+    </div>
+  </div>
+
+  {{if .State.Reasons}}
+  <div class="card" style="border-color:var(--unsafe-border);">
+    <div class="card-title" style="color:var(--unsafe);">Unsafe Reasons</div>
+    <ul class="reasons-list">
+      {{range .State.Reasons}}<li>{{.}}</li>{{end}}
+    </ul>
+  </div>
+  {{end}}
+
+  {{if .State.Warnings}}
+  <div class="card" style="border-color:var(--warn-border);">
+    <div class="card-title" style="color:var(--warn);">Warnings / Cautions</div>
+    <ul class="warnings-list">
+      {{range .State.Warnings}}<li>{{.}}</li>{{end}}
+    </ul>
+  </div>
+  {{end}}
+
+  <div class="card">
+    <div class="card-title">Safety Rules</div>
+    {{if .SafetyRules}}
+    <table class="data-table">
+      <thead>
+        <tr>
+          <th>Rule</th>
+          <th>Threshold</th>
+          <th>Current</th>
+          <th>Result</th>
+          <th>Enabled</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{range .SafetyRules}}
+        <tr>
+          <td>{{.Name}}</td>
+          <td class="mono">{{.Threshold}}</td>
+          <td class="mono">{{.Current}}</td>
+          <td>
+            <span class="result-badge {{.Result}}">
+              {{if eq .Result "pass"}}✓ pass{{else if eq .Result "fail"}}✗ fail{{else if eq .Result "warn"}}⚠ caution{{else}}— n/a{{end}}
+            </span>
+          </td>
+          <td {{if not .Enabled}}class="disabled"{{end}}>{{if .Enabled}}yes{{else}}no (disabled){{end}}</td>
+        </tr>
+        {{end}}
+      </tbody>
+    </table>
+    {{else}}
+    <div class="not-available">No safety rules configured.</div>
+    {{end}}
+  </div>
+
+</div><!-- /safety -->
+
+<!-- ===================== OBSERVING CONDITIONS ===================== -->
+<div id="pg-observing-conditions" class="page">
+  <div class="section-title">Observing Conditions</div>
+
+  <div class="filter-bar">
+    <button class="filter-btn active" onclick="filterOC('all', this)">All</button>
+    <button class="filter-btn" onclick="filterOC('available', this)">Available</button>
+    <button class="filter-btn" onclick="filterOC('missing-unsupported', this)">Missing / Unsupported</button>
+  </div>
+
+  <div class="card">
+    <table class="data-table" id="oc-table">
+      <thead>
+        <tr>
+          <th>Alpaca Property</th>
+          <th>SQMeter Source</th>
+          <th>Value</th>
+          <th>Unit</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{range .OCProps}}
+        <tr data-oc-status="{{.Status}}">
+          <td>{{.AlpacaName}}</td>
+          <td class="mono muted">{{.Source}}</td>
+          <td class="mono {{if eq .Status "available"}}{{else}}muted{{end}}">{{.Value}}</td>
+          <td class="mono muted">{{.Unit}}</td>
+          <td><span class="status-badge {{.Status}}">{{.Status}}</span></td>
+        </tr>
+        {{end}}
+      </tbody>
+    </table>
+  </div>
+
+</div><!-- /observing-conditions -->
+
+<!-- ===================== DIAGNOSTICS ===================== -->
+<div id="pg-diagnostics" class="page">
+  <div class="section-title">Diagnostics</div>
+
+  <div class="tab-bar">
+    <button class="tab-btn active" onclick="showDiagTab('logs', this)">Logs</button>
+    <button class="tab-btn" onclick="showDiagTab('payload', this)">Raw Payload</button>
+    <button class="tab-btn" onclick="showDiagTab('endpoints', this)">Endpoints</button>
+    <button class="tab-btn" onclick="showDiagTab('discovery', this)">Discovery</button>
+  </div>
+
+  <!-- Logs -->
+  <div id="dtab-logs" class="tab-panel active">
+    <div class="not-available">Log streaming is not yet available in this version. Check the terminal or service log file for output.</div>
+  </div>
+
+  <!-- Raw Payload -->
+  <div id="dtab-payload" class="tab-panel">
+    {{if .RawPayload}}
+    <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;">
+      <span style="font-size:0.72rem;color:var(--muted);">Source: <span style="font-family:var(--mono);">{{.SQMeterURL}}/api/sensors</span></span>
+      <button class="btn-copy" onclick="copyRawPayload()">copy</button>
+    </div>
+    <div class="code-block" id="raw-payload">{{.RawPayload}}</div>
+    {{else}}
+    <div class="not-available">No SQMeter payload available yet. Data will appear after the first successful poll.</div>
+    {{end}}
+  </div>
+
+  <!-- Endpoints -->
+  <div id="dtab-endpoints" class="tab-panel">
+    <div style="margin-bottom:8px;font-size:0.72rem;color:var(--muted);">
+      Base URL: <span id="ep-base" style="font-family:var(--mono);"></span>
+    </div>
+    <div class="endpoint-list">
+      <div class="endpoint-row">
+        <span class="ep-path"><a href="/management/apiversions" target="_blank">/management/apiversions</a></span>
+        <button class="btn-copy" onclick="copyEP('/management/apiversions')">copy</button>
+      </div>
+      <div class="endpoint-row">
+        <span class="ep-path"><a href="/management/v1/configureddevices" target="_blank">/management/v1/configureddevices</a></span>
+        <button class="btn-copy" onclick="copyEP('/management/v1/configureddevices')">copy</button>
+      </div>
+      <div class="endpoint-row">
+        <span class="ep-path"><a href="/api/v1/safetymonitor/0/issafe" target="_blank">/api/v1/safetymonitor/0/issafe</a></span>
+        <button class="btn-copy" onclick="copyEP('/api/v1/safetymonitor/0/issafe')">copy</button>
+      </div>
+      <div class="endpoint-row">
+        <span class="ep-path"><a href="/api/v1/observingconditions/0/cloudcover" target="_blank">/api/v1/observingconditions/0/cloudcover</a></span>
+        <button class="btn-copy" onclick="copyEP('/api/v1/observingconditions/0/cloudcover')">copy</button>
+      </div>
+      <div class="endpoint-row">
+        <span class="ep-path"><a href="/api/v1/observingconditions/0/skyquality" target="_blank">/api/v1/observingconditions/0/skyquality</a></span>
+        <button class="btn-copy" onclick="copyEP('/api/v1/observingconditions/0/skyquality')">copy</button>
+      </div>
+      <div class="endpoint-row">
+        <span class="ep-path"><a href="/status.json" target="_blank">/status.json</a></span>
+        <button class="btn-copy" onclick="copyEP('/status.json')">copy</button>
+      </div>
+      <div class="endpoint-row">
+        <span class="ep-path"><a href="/health" target="_blank">/health</a></span>
+        <button class="btn-copy" onclick="copyEP('/health')">copy</button>
+      </div>
+      <div class="endpoint-row">
+        <span class="ep-path"><a href="/setup" target="_blank">/setup</a></span>
+        <button class="btn-copy" onclick="copyEP('/setup')">copy</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Discovery -->
+  <div id="dtab-discovery" class="tab-panel">
+    {{if .DiscoveryHasStats}}
+    <div class="card" style="margin-bottom:0;">
+      <div class="kv"><span class="k">Running</span><span class="v {{if .DiscoveryRunning}}ok{{else}}err{{end}}">{{if .DiscoveryRunning}}yes{{else}}no — not running{{end}}</span></div>
+      <div class="kv"><span class="k">UDP port</span><span class="v">{{.DiscoveryPort}}</span></div>
+      <div class="kv"><span class="k">Advertised HTTP port</span><span class="v">{{.HTTPPort}}</span></div>
+      {{if .DiscoveryError}}
+      <div class="kv"><span class="k">Last error</span><span class="v err" style="font-size:0.72rem;max-width:320px;word-break:break-all;">{{.DiscoveryError}}</span></div>
+      {{end}}
+    </div>
+    {{else}}
+    <div class="not-available">Discovery status not available.</div>
+    {{end}}
+  </div>
+
+</div><!-- /diagnostics -->
+
+</main>
+</div><!-- /layout -->
+
 <script>
+// Base URL display
+(function() {
+  var el = document.getElementById('ep-base');
+  if (el) el.textContent = location.origin;
+})();
+
+// Navigation
+var pages = ['overview','configuration','safety','observing-conditions','diagnostics'];
+
+function showPage(name) {
+  pages.forEach(function(p) {
+    var el = document.getElementById('pg-' + p);
+    if (el) el.classList.toggle('active', p === name);
+  });
+  document.querySelectorAll('.nav-item').forEach(function(a) {
+    a.classList.toggle('active', a.dataset.page === name);
+  });
+  history.replaceState(null, '', '#' + name);
+}
+
+document.querySelectorAll('.nav-item').forEach(function(a) {
+  a.addEventListener('click', function(e) {
+    e.preventDefault();
+    showPage(this.dataset.page);
+  });
+});
+
+(function() {
+  var hash = location.hash.replace('#','');
+  if (pages.indexOf(hash) !== -1) showPage(hash);
+})();
+
+// Diagnostics tabs
+function showDiagTab(name, btn) {
+  document.querySelectorAll('.tab-panel').forEach(function(p) {
+    p.classList.remove('active');
+  });
+  document.querySelectorAll('.tab-btn').forEach(function(b) {
+    b.classList.remove('active');
+  });
+  var panel = document.getElementById('dtab-' + name);
+  if (panel) panel.classList.add('active');
+  if (btn) btn.classList.add('active');
+}
+
+// OC filter
+function filterOC(filter, btn) {
+  document.querySelectorAll('.filter-btn').forEach(function(b) { b.classList.remove('active'); });
+  if (btn) btn.classList.add('active');
+  document.querySelectorAll('#oc-table tbody tr').forEach(function(row) {
+    var st = row.dataset.ocStatus;
+    if (filter === 'all') {
+      row.style.display = '';
+    } else if (filter === 'available') {
+      row.style.display = st === 'available' ? '' : 'none';
+    } else if (filter === 'missing-unsupported') {
+      row.style.display = (st === 'missing' || st === 'unsupported') ? '' : 'none';
+    }
+  });
+}
+
+// Copy helpers
+function copyText(text) {
+  if (navigator.clipboard) {
+    navigator.clipboard.writeText(text).catch(function(){});
+  }
+}
+function copyEP(path) {
+  copyText(location.protocol + '//' + location.host + path);
+}
+function copyRawPayload() {
+  var el = document.getElementById('raw-payload');
+  if (el) copyText(el.textContent);
+}
+
+// Config save
+function saveConfig() {
+  var data = {};
+  var strFields = ['SQMETER_BASE_URL','ALPACA_HTTP_BIND','MANUAL_OVERRIDE','LOG_LEVEL'];
+  var intFields = ['ALPACA_HTTP_PORT','ALPACA_DISCOVERY_PORT','POLL_INTERVAL_SECONDS','STALE_AFTER_SECONDS'];
+  var boolFields = ['FAIL_CLOSED','CONNECTED_ON_STARTUP','REQUIRE_LIGHT_SENSOR_STATUS_OK','REQUIRE_ENVIRONMENT_STATUS_OK','REQUIRE_IR_TEMPERATURE_STATUS_OK'];
+  var optFloatFields = ['CLOUD_COVER_UNSAFE_PERCENT','CLOUD_COVER_CAUTION_PERCENT','SQM_MIN_SAFE','HUMIDITY_MAX_SAFE','DEWPOINT_MARGIN_MIN_C'];
+
+  strFields.forEach(function(k) {
+    var el = document.getElementById('cfg-' + k);
+    if (el) data[k] = el.value;
+  });
+  intFields.forEach(function(k) {
+    var el = document.getElementById('cfg-' + k);
+    if (el && el.value !== '') { var n = parseInt(el.value, 10); if (!isNaN(n)) data[k] = n; }
+  });
+  boolFields.forEach(function(k) {
+    var el = document.getElementById('cfg-' + k);
+    if (el) data[k] = el.checked;
+  });
+  optFloatFields.forEach(function(k) {
+    var el = document.getElementById('cfg-' + k);
+    if (el) {
+      var v = el.value.trim();
+      if (v === '') { data[k] = null; } else { var f = parseFloat(v); if (!isNaN(f)) data[k] = f; }
+    }
+  });
+
+  var fb = document.getElementById('cfg-feedback');
+  var rn = document.getElementById('cfg-restart-notice');
+  fb.textContent = 'Saving…';
+  fb.className = '';
+
+  fetch('/config.json', {
+    method: 'PUT',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(data)
+  })
+  .then(function(r) { return r.json().then(function(d) { return {ok: r.ok, body: d}; }); })
+  .then(function(res) {
+    if (!res.ok) {
+      fb.textContent = '✗ ' + (res.body.error || 'save failed');
+      fb.className = 'err';
+      rn.style.display = 'none';
+      return;
+    }
+    fb.textContent = '✓ Saved';
+    fb.className = 'ok';
+    if (res.body.restart_required && res.body.restart_required_fields && res.body.restart_required_fields.length) {
+      rn.style.display = 'block';
+      document.getElementById('cfg-restart-fields').textContent = res.body.restart_required_fields.join(', ');
+    } else {
+      rn.style.display = 'none';
+    }
+    setTimeout(function() { if (fb.className === 'ok') { fb.textContent = ''; fb.className = ''; } }, 4000);
+  })
+  .catch(function(err) {
+    fb.textContent = '✗ ' + err;
+    fb.className = 'err';
+  });
+}
+
+// SQMeter connection test
+function testSQMeter() {
+  var url = document.getElementById('cfg-SQMETER_BASE_URL');
+  var el = document.getElementById('cfg-test-result');
+  el.className = 'test-result';
+  el.textContent = 'Testing…';
+  fetch('/api/test-sqmeter', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({url: url ? url.value.trim() : ''})
+  })
+  .then(function(r) { return r.json(); })
+  .then(function(d) {
+    el.className = 'test-result ' + (d.ok ? 'ok' : 'err');
+    el.textContent = (d.ok ? '✓ ' : '✗ ') + d.message;
+  })
+  .catch(function(e) {
+    el.className = 'test-result err';
+    el.textContent = '✗ ' + e;
+  });
+}
+
+// Service controls
 function svcAction(action) {
   var msgs = {
-    restart: 'Restart the service?\n\nThe service will exit and restart if the service manager is configured to do so (Windows Service recovery, NSSM, or systemd Restart=on-failure). It will briefly be unavailable.',
+    restart: 'Restart the service?\n\nThe service will exit and restart if the service manager is configured to do so. It will briefly be unavailable.',
     stop:    'Stop the service?\n\nWARNING: This will shut down the safety bridge. N.I.N.A. and all Alpaca clients will lose safety integration until the service is manually restarted.\n\nAre you sure?'
   };
   if (!window.confirm(msgs[action])) return;
   var msg = document.getElementById('svc-msg');
   msg.textContent = 'Sending ' + action + ' request…';
   msg.style.display = 'block';
-  msg.style.color = '#8892a4';
+  msg.style.color = 'var(--muted)';
   fetch('/api/service/' + action, {method: 'POST'})
     .then(function(r) { return r.json(); })
     .then(function(d) {
       msg.textContent = d.message || (d.ok ? 'Done.' : 'Failed.');
-      msg.style.color = d.ok ? '#2ecc71' : '#e74c3c';
+      msg.style.color = d.ok ? 'var(--safe)' : 'var(--unsafe)';
     })
     .catch(function() {
       msg.textContent = action + ' command sent — service is shutting down.';
-      msg.style.color = '#f39c12';
+      msg.style.color = 'var(--warn)';
     });
 }
 </script>
-{{end}}
-
-<div class="links">
-  Alpaca:
-  <a href="/management/apiversions">/apiversions</a>
-  <a href="/management/v1/configureddevices">/configureddevices</a>
-  <a href="/api/v1/safetymonitor/0/issafe">/issafe</a>
-  &nbsp;|&nbsp;
-  <a href="/status.json">/status.json</a>
-  <a href="/health">/health</a>
-  <a href="/setup">/setup</a>
-</div>
-
-<footer>
-  Refreshes every 10 seconds &nbsp;·&nbsp;
-  <a href="/status.json" style="color:#5b9bd5">status.json</a>
-</footer>
 
 </body>
 </html>


### PR DESCRIPTION
Closes #53

## Summary

- Rebuilds the web dashboard as a compact dark-mode local infrastructure UI named **ASCOM SQMeter Bridge**, replacing the single-page status view with a 5-section sidebar layout (Overview, Configuration, Safety Monitor, Observing Conditions, Diagnostics)
- All content is driven by real bridge state (`state.EvaluatedState`, `config.Config`) — no mock data or non-functional controls
- Fixes a Go 1.22 `ServeMux` pattern conflict panic caused by `"GET /"` and the Alpaca `"/api/"` catch-all; changed to method-agnostic `"/"` with a path guard in the handler so unknown paths return 404 rather than the dashboard

## Changes

**`internal/web/handlers.go`**
- `Register`: `"GET /"` → `"/"` to resolve Go 1.22 route conflict
- `Dashboard`: path guard — only `/` and `/status` serve dashboard HTML; all other paths return 404
- New `OCProperty` and `SafetyRule` structs + extended `DashboardData`
- `buildOCProperties` / `buildSafetyRules` server-side helpers

**`internal/web/templates/dashboard.html`**
- Full rewrite: dark-mode CSS, sidebar navigation, 5 section pages, OC property table with JS filter, safety rules table, config form (PUT `/config.json`), diagnostics sub-tabs (Raw Payload, Endpoints, Discovery)

**`internal/web/handlers_test.go`**
- 5 new tests: branding, SafetyMonitor/0 presence, ObservingConditions/0 presence, network-exposure warning (wide-open vs loopback)
- Updated `TestServiceRestart_GET_DoesNotTriggerAction` and `TestServiceStop_GET_DoesNotTriggerAction` to expect 404 (correct behaviour after path guard)

**`internal/web/routes_integration_test.go`** *(new)*
- Integration test: registers alpaca + web handlers together, verifies no ServeMux panic, bad `/api/` paths return JSON 404, valid Alpaca endpoint returns 200

## Test plan

- [ ] `go test ./...` — all packages pass
- [ ] `go vet ./...` — clean
- [ ] `go build ./cmd/sqmeter-ascom-alpaca` — builds
- [ ] `GET /` returns dashboard HTML with "ASCOM SQMeter Bridge" branding
- [ ] `GET /nonexistent` returns 404
- [ ] `GET /api/v1/badpath` returns JSON 404, not dashboard HTML
- [ ] `GET /api/v1/safetymonitor/0/issafe` returns Alpaca JSON
- [ ] Network-exposure warning appears when bind is `0.0.0.0`